### PR TITLE
feat(core): implementar DialogueGraph Resource

### DIFF
--- a/addons/ohmydialog/icons/dialogue_graph.svg
+++ b/addons/ohmydialog/icons/dialogue_graph.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Dialogue Graph icon - connected nodes -->
+  <!-- Node 1 (top-left) -->
+  <rect x="1" y="2" width="4" height="3" rx="0.8" fill="#10b981" stroke="#8da5f3" stroke-width="0.5"/>
+  <!-- Node 2 (top-right) -->
+  <rect x="11" y="2" width="4" height="3" rx="0.8" fill="#3b82f6" stroke="#8da5f3" stroke-width="0.5"/>
+  <!-- Node 3 (bottom-center) -->
+  <rect x="6" y="11" width="4" height="3" rx="0.8" fill="#eab308" stroke="#8da5f3" stroke-width="0.5"/>
+  <!-- Connection lines -->
+  <path d="M5 3.5 L11 3.5" stroke="#e0e0e0" stroke-width="0.8" fill="none"/>
+  <path d="M3 5 L8 11" stroke="#e0e0e0" stroke-width="0.8" fill="none"/>
+  <path d="M13 5 L8 11" stroke="#e0e0e0" stroke-width="0.8" fill="none"/>
+  <!-- Connection dots -->
+  <circle cx="5" cy="3.5" r="0.8" fill="#f6c358"/>
+  <circle cx="11" cy="3.5" r="0.8" fill="#f6c358"/>
+  <circle cx="8" cy="11" r="0.8" fill="#f6c358"/>
+</svg>

--- a/addons/ohmydialog/resources/dialogue_graph.gd
+++ b/addons/ohmydialog/resources/dialogue_graph.gd
@@ -1,0 +1,441 @@
+@tool
+@icon("res://addons/ohmydialog/icons/dialogue_graph.svg")
+class_name DialogueGraph
+extends Resource
+## A complete dialogue graph containing nodes and connections.
+##
+## DialogueGraph stores the structure of a conversation including all nodes,
+## their connections, and references to character/world context. It supports
+## the hybrid dialogue system with scripted, free, and mixed modes.
+##
+## @tutorial: See docs/API/resources.html for detailed documentation.
+
+
+## Emitted when a node is added to the graph.
+signal node_added(node: DialogueNodeData)
+
+## Emitted when a node is removed from the graph.
+signal node_removed(node_id: String)
+
+## Emitted when a connection is created between nodes.
+signal connection_added(from_node: String, from_slot: int, to_node: String, to_slot: int)
+
+## Emitted when a connection is removed.
+signal connection_removed(from_node: String, from_slot: int, to_node: String, to_slot: int)
+
+
+@export_group("Graph Identity")
+
+## Unique identifier for this dialogue graph.
+@export var graph_id: String = ""
+
+## Human-readable name displayed in the editor.
+@export var display_name: String = ""
+
+## Description of what this dialogue is about.
+## Example: "Main quest dialogue with the blacksmith about the legendary sword."
+@export_multiline var description: String = ""
+
+
+@export_group("Context")
+
+## Default character identity for AI responses in this graph.
+## Individual nodes can override this.
+@export var default_character: CharacterIdentity = null
+
+## World context to use for this dialogue.
+## Provides setting, lore, and current events to the LLM.
+@export var world_context: WorldContext = null
+
+
+@export_group("Graph Data")
+
+## Dictionary of node_id -> DialogueNodeData.
+## Contains all nodes in this graph.
+@export var nodes: Dictionary = {}
+
+## Array of connection dictionaries.
+## Each connection: {from_node: String, from_slot: int, to_node: String, to_slot: int}
+@export var connections: Array[Dictionary] = []
+
+## The node_id of the start node (entry point of the dialogue).
+@export var start_node_id: String = ""
+
+
+@export_group("Variables")
+
+## Local variables scoped to this dialogue graph.
+## These are reset each time the dialogue starts.
+## Example: {"talked_about_sword": false, "bribe_amount": 0}
+@export var local_variables: Dictionary = {}
+
+
+@export_group("Editor")
+
+## Metadata for the visual editor (zoom, scroll position, etc.)
+## Not used at runtime, only for editor state persistence.
+@export var editor_metadata: Dictionary = {}
+
+
+# ==================== Node Management ====================
+
+
+## Adds a node to the graph.
+## Returns the node_id of the added node.
+func add_node(node: DialogueNodeData) -> String:
+	if node.node_id.is_empty():
+		push_error("DialogueGraph: Cannot add node with empty node_id")
+		return ""
+
+	if nodes.has(node.node_id):
+		push_warning("DialogueGraph: Node %s already exists, replacing" % node.node_id)
+
+	nodes[node.node_id] = node
+
+	# If this is a START node and we don't have a start_node_id, set it
+	if node.node_type == DialogueNodeData.NodeType.START and start_node_id.is_empty():
+		start_node_id = node.node_id
+
+	node_added.emit(node)
+	return node.node_id
+
+
+## Creates and adds a new node of the specified type.
+## Returns the created node.
+func create_node(type: DialogueNodeData.NodeType, position: Vector2 = Vector2.ZERO) -> DialogueNodeData:
+	var node := DialogueNodeData.new(type)
+	node.editor_position = position
+	add_node(node)
+	return node
+
+
+## Removes a node and all its connections from the graph.
+func remove_node(node_id: String) -> void:
+	if not nodes.has(node_id):
+		push_warning("DialogueGraph: Node %s not found" % node_id)
+		return
+
+	# Remove all connections involving this node
+	var connections_to_remove: Array[Dictionary] = []
+	for conn in connections:
+		if conn.from_node == node_id or conn.to_node == node_id:
+			connections_to_remove.append(conn)
+
+	for conn in connections_to_remove:
+		disconnect_nodes(conn.from_node, conn.from_slot, conn.to_node, conn.to_slot)
+
+	# Remove the node
+	nodes.erase(node_id)
+
+	# Clear start_node_id if we removed the start node
+	if start_node_id == node_id:
+		start_node_id = ""
+		_find_new_start_node()
+
+	node_removed.emit(node_id)
+
+
+## Returns a node by its ID, or null if not found.
+func get_node(node_id: String) -> DialogueNodeData:
+	return nodes.get(node_id, null)
+
+
+## Returns true if the graph contains a node with the given ID.
+func has_node(node_id: String) -> bool:
+	return nodes.has(node_id)
+
+
+## Returns all nodes of a specific type.
+func get_nodes_by_type(type: DialogueNodeData.NodeType) -> Array[DialogueNodeData]:
+	var result: Array[DialogueNodeData] = []
+	for node_id in nodes:
+		var node: DialogueNodeData = nodes[node_id]
+		if node.node_type == type:
+			result.append(node)
+	return result
+
+
+## Returns the start node, or null if not set.
+func get_start_node() -> DialogueNodeData:
+	if start_node_id.is_empty():
+		return null
+	return get_node(start_node_id)
+
+
+## Finds and sets a new start node if the current one is missing.
+func _find_new_start_node() -> void:
+	var start_nodes := get_nodes_by_type(DialogueNodeData.NodeType.START)
+	if start_nodes.size() > 0:
+		start_node_id = start_nodes[0].node_id
+
+
+# ==================== Connection Management ====================
+
+
+## Creates a connection between two nodes.
+## Returns true if the connection was created successfully.
+func connect_nodes(from_node: String, from_slot: int, to_node: String, to_slot: int = 0) -> bool:
+	# Validate nodes exist
+	if not nodes.has(from_node):
+		push_error("DialogueGraph: Source node %s not found" % from_node)
+		return false
+	if not nodes.has(to_node):
+		push_error("DialogueGraph: Target node %s not found" % to_node)
+		return false
+
+	# Check if connection already exists
+	for conn in connections:
+		if conn.from_node == from_node and conn.from_slot == from_slot \
+		   and conn.to_node == to_node and conn.to_slot == to_slot:
+			push_warning("DialogueGraph: Connection already exists")
+			return false
+
+	# Validate slot is within range
+	var source_node: DialogueNodeData = nodes[from_node]
+	if from_slot >= source_node.output_count:
+		push_error("DialogueGraph: Slot %d out of range for node %s (has %d outputs)" % [from_slot, from_node, source_node.output_count])
+		return false
+
+	# Create connection
+	var connection := {
+		"from_node": from_node,
+		"from_slot": from_slot,
+		"to_node": to_node,
+		"to_slot": to_slot
+	}
+	connections.append(connection)
+
+	connection_added.emit(from_node, from_slot, to_node, to_slot)
+	return true
+
+
+## Removes a specific connection.
+func disconnect_nodes(from_node: String, from_slot: int, to_node: String, to_slot: int = 0) -> void:
+	for i in range(connections.size() - 1, -1, -1):
+		var conn: Dictionary = connections[i]
+		if conn.from_node == from_node and conn.from_slot == from_slot \
+		   and conn.to_node == to_node and conn.to_slot == to_slot:
+			connections.remove_at(i)
+			connection_removed.emit(from_node, from_slot, to_node, to_slot)
+			return
+
+
+## Removes all connections from a specific output slot.
+func disconnect_slot(node_id: String, slot: int) -> void:
+	for i in range(connections.size() - 1, -1, -1):
+		var conn: Dictionary = connections[i]
+		if conn.from_node == node_id and conn.from_slot == slot:
+			connections.remove_at(i)
+			connection_removed.emit(conn.from_node, conn.from_slot, conn.to_node, conn.to_slot)
+
+
+## Returns all connections from a node's output slot.
+func get_connections_from(node_id: String, slot: int = -1) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for conn in connections:
+		if conn.from_node == node_id:
+			if slot == -1 or conn.from_slot == slot:
+				result.append(conn)
+	return result
+
+
+## Returns all connections to a node.
+func get_connections_to(node_id: String) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for conn in connections:
+		if conn.to_node == node_id:
+			result.append(conn)
+	return result
+
+
+## Returns the next node(s) from a given node and slot.
+## For most nodes, returns a single node. For CONDITION nodes, slot matters.
+func get_next_nodes(node_id: String, slot: int = 0) -> Array[DialogueNodeData]:
+	var result: Array[DialogueNodeData] = []
+	var conns := get_connections_from(node_id, slot)
+	for conn in conns:
+		var node := get_node(conn.to_node)
+		if node:
+			result.append(node)
+	return result
+
+
+## Returns the single next node, or null if none/multiple.
+## Use for linear flow (non-branching nodes).
+func get_next_node(node_id: String, slot: int = 0) -> DialogueNodeData:
+	var next_nodes := get_next_nodes(node_id, slot)
+	if next_nodes.size() == 1:
+		return next_nodes[0]
+	return null
+
+
+# ==================== Validation ====================
+
+
+## Validates the entire graph structure.
+## Returns an array of error messages (empty if valid).
+func validate() -> Array[String]:
+	var errors: Array[String] = []
+
+	# Check basic requirements
+	if graph_id.is_empty():
+		errors.append("Graph ID is empty")
+
+	if nodes.is_empty():
+		errors.append("Graph has no nodes")
+		return errors
+
+	# Check for start node
+	if start_node_id.is_empty():
+		errors.append("No start node defined")
+	elif not nodes.has(start_node_id):
+		errors.append("Start node '%s' not found in graph" % start_node_id)
+
+	# Validate each node
+	for node_id in nodes:
+		var node: DialogueNodeData = nodes[node_id]
+		var node_errors := node.validate()
+		for err in node_errors:
+			errors.append("Node '%s': %s" % [node_id, err])
+
+	# Validate connections reference existing nodes
+	for conn in connections:
+		if not nodes.has(conn.from_node):
+			errors.append("Connection references missing node: %s" % conn.from_node)
+		if not nodes.has(conn.to_node):
+			errors.append("Connection references missing node: %s" % conn.to_node)
+
+	# Check for orphan nodes (except START)
+	for node_id in nodes:
+		var node: DialogueNodeData = nodes[node_id]
+		if node.node_type != DialogueNodeData.NodeType.START:
+			var incoming := get_connections_to(node_id)
+			if incoming.is_empty():
+				errors.append("Node '%s' has no incoming connections (orphan)" % node_id)
+
+	# Check for dead ends (nodes with outputs but no connections, except END)
+	for node_id in nodes:
+		var node: DialogueNodeData = nodes[node_id]
+		if node.output_count > 0 and node.node_type != DialogueNodeData.NodeType.END:
+			var outgoing := get_connections_from(node_id)
+			if outgoing.is_empty():
+				errors.append("Node '%s' has no outgoing connections (dead end)" % node_id)
+
+	return errors
+
+
+## Returns true if the graph is valid.
+func is_valid() -> bool:
+	return validate().is_empty()
+
+
+# ==================== Serialization ====================
+
+
+## Serializes the graph to a dictionary for JSON/storage.
+func to_dict() -> Dictionary:
+	var nodes_dict := {}
+	for node_id in nodes:
+		nodes_dict[node_id] = nodes[node_id].to_dict()
+
+	return {
+		"graph_id": graph_id,
+		"display_name": display_name,
+		"description": description,
+		"nodes": nodes_dict,
+		"connections": connections.duplicate(true),
+		"start_node_id": start_node_id,
+		"local_variables": local_variables.duplicate(),
+		"editor_metadata": editor_metadata.duplicate()
+	}
+
+
+## Creates a DialogueGraph from a dictionary.
+static func from_dict(dict: Dictionary) -> DialogueGraph:
+	var graph := DialogueGraph.new()
+	graph.graph_id = dict.get("graph_id", "")
+	graph.display_name = dict.get("display_name", "")
+	graph.description = dict.get("description", "")
+	graph.start_node_id = dict.get("start_node_id", "")
+	graph.local_variables = dict.get("local_variables", {}).duplicate()
+	graph.editor_metadata = dict.get("editor_metadata", {}).duplicate()
+
+	# Reconstruct nodes
+	var nodes_dict: Dictionary = dict.get("nodes", {})
+	for node_id in nodes_dict:
+		var node := DialogueNodeData.from_dict(nodes_dict[node_id])
+		graph.nodes[node_id] = node
+
+	# Reconstruct connections
+	var conns: Array = dict.get("connections", [])
+	for conn in conns:
+		graph.connections.append({
+			"from_node": conn.get("from_node", ""),
+			"from_slot": conn.get("from_slot", 0),
+			"to_node": conn.get("to_node", ""),
+			"to_slot": conn.get("to_slot", 0)
+		})
+
+	return graph
+
+
+# ==================== Utilities ====================
+
+
+## Returns a short summary of the graph for debugging.
+func get_summary() -> String:
+	return "%s (%s) - %d nodes, %d connections" % [
+		display_name if not display_name.is_empty() else "Unnamed Graph",
+		graph_id if not graph_id.is_empty() else "no-id",
+		nodes.size(),
+		connections.size()
+	]
+
+
+## Clears all nodes and connections from the graph.
+func clear() -> void:
+	nodes.clear()
+	connections.clear()
+	start_node_id = ""
+
+
+## Duplicates the graph with new node IDs.
+func duplicate_graph() -> DialogueGraph:
+	var new_graph := DialogueGraph.new()
+	new_graph.graph_id = graph_id + "_copy"
+	new_graph.display_name = display_name + " (Copy)"
+	new_graph.description = description
+	new_graph.default_character = default_character
+	new_graph.world_context = world_context
+	new_graph.local_variables = local_variables.duplicate()
+	new_graph.editor_metadata = editor_metadata.duplicate()
+
+	# Create mapping of old IDs to new IDs
+	var id_map: Dictionary = {}
+
+	# Duplicate nodes with new IDs
+	for old_id in nodes:
+		var old_node: DialogueNodeData = nodes[old_id]
+		var new_node := DialogueNodeData.new(old_node.node_type)
+		new_node.editor_position = old_node.editor_position
+		new_node.data = old_node.data.duplicate(true)
+		new_node.output_count = old_node.output_count
+
+		id_map[old_id] = new_node.node_id
+		new_graph.nodes[new_node.node_id] = new_node
+
+	# Update start_node_id
+	if id_map.has(start_node_id):
+		new_graph.start_node_id = id_map[start_node_id]
+
+	# Duplicate connections with new IDs
+	for conn in connections:
+		if id_map.has(conn.from_node) and id_map.has(conn.to_node):
+			new_graph.connections.append({
+				"from_node": id_map[conn.from_node],
+				"from_slot": conn.from_slot,
+				"to_node": id_map[conn.to_node],
+				"to_slot": conn.to_slot
+			})
+
+	return new_graph

--- a/docs/API/resources.html
+++ b/docs/API/resources.html
@@ -577,6 +577,201 @@ var context = world.to_context_prompt()</code></pre>
 
       <hr>
 
+      <!-- ==================== DialogueGraph ==================== -->
+      <h2 id="dialogue-graph">
+        <div class="resource-header">
+          <span class="icon">🔗</span>
+          <span>DialogueGraph</span>
+        </div>
+      </h2>
+
+      <p>Contiene un grafo completo de diálogo con todos los nodos, conexiones y contexto. Es el recurso principal que se carga para ejecutar una conversación.</p>
+
+      <p><strong>Archivo:</strong> <code>addons/ohmydialog/resources/dialogue_graph.gd</code></p>
+
+      <h3>Propiedades</h3>
+
+      <table class="property-table">
+        <thead>
+          <tr>
+            <th>Grupo</th>
+            <th>Propiedad</th>
+            <th>Tipo</th>
+            <th>Descripción</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="3"><strong>Graph Identity</strong></td>
+            <td><code>graph_id</code></td>
+            <td>String</td>
+            <td>ID único del grafo</td>
+          </tr>
+          <tr>
+            <td><code>display_name</code></td>
+            <td>String</td>
+            <td>Nombre mostrado en el editor</td>
+          </tr>
+          <tr>
+            <td><code>description</code></td>
+            <td>String</td>
+            <td>Descripción del diálogo</td>
+          </tr>
+          <tr>
+            <td rowspan="2"><strong>Context</strong></td>
+            <td><code>default_character</code></td>
+            <td>CharacterIdentity</td>
+            <td>Personaje por defecto para respuestas IA</td>
+          </tr>
+          <tr>
+            <td><code>world_context</code></td>
+            <td>WorldContext</td>
+            <td>Contexto del mundo</td>
+          </tr>
+          <tr>
+            <td rowspan="3"><strong>Graph Data</strong></td>
+            <td><code>nodes</code></td>
+            <td>Dictionary</td>
+            <td>node_id → DialogueNodeData</td>
+          </tr>
+          <tr>
+            <td><code>connections</code></td>
+            <td>Array[Dictionary]</td>
+            <td>Conexiones entre nodos</td>
+          </tr>
+          <tr>
+            <td><code>start_node_id</code></td>
+            <td>String</td>
+            <td>ID del nodo de inicio</td>
+          </tr>
+          <tr>
+            <td><strong>Variables</strong></td>
+            <td><code>local_variables</code></td>
+            <td>Dictionary</td>
+            <td>Variables locales del diálogo</td>
+          </tr>
+          <tr>
+            <td><strong>Editor</strong></td>
+            <td><code>editor_metadata</code></td>
+            <td>Dictionary</td>
+            <td>Metadatos del editor visual</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Signals</h3>
+
+      <table class="property-table">
+        <thead>
+          <tr>
+            <th>Signal</th>
+            <th>Parámetros</th>
+            <th>Descripción</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>node_added</code></td>
+            <td><code>node: DialogueNodeData</code></td>
+            <td>Emitido al agregar un nodo</td>
+          </tr>
+          <tr>
+            <td><code>node_removed</code></td>
+            <td><code>node_id: String</code></td>
+            <td>Emitido al eliminar un nodo</td>
+          </tr>
+          <tr>
+            <td><code>connection_added</code></td>
+            <td><code>from_node, from_slot, to_node, to_slot</code></td>
+            <td>Emitido al crear conexión</td>
+          </tr>
+          <tr>
+            <td><code>connection_removed</code></td>
+            <td><code>from_node, from_slot, to_node, to_slot</code></td>
+            <td>Emitido al eliminar conexión</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Métodos Principales</h3>
+
+      <h4>Gestión de Nodos</h4>
+
+      <div class="method-signature">func add_node(node: DialogueNodeData) -> String</div>
+      <p class="method-desc">Agrega un nodo al grafo. Retorna el node_id.</p>
+
+      <div class="method-signature">func create_node(type: NodeType, position: Vector2 = Vector2.ZERO) -> DialogueNodeData</div>
+      <p class="method-desc">Crea y agrega un nuevo nodo del tipo especificado.</p>
+
+      <div class="method-signature">func remove_node(node_id: String) -> void</div>
+      <p class="method-desc">Elimina un nodo y todas sus conexiones.</p>
+
+      <div class="method-signature">func get_node(node_id: String) -> DialogueNodeData</div>
+      <p class="method-desc">Obtiene un nodo por su ID.</p>
+
+      <div class="method-signature">func get_start_node() -> DialogueNodeData</div>
+      <p class="method-desc">Obtiene el nodo de inicio del grafo.</p>
+
+      <h4>Gestión de Conexiones</h4>
+
+      <div class="method-signature">func connect_nodes(from_node: String, from_slot: int, to_node: String, to_slot: int = 0) -> bool</div>
+      <p class="method-desc">Crea una conexión entre dos nodos. Retorna true si tuvo éxito.</p>
+
+      <div class="method-signature">func disconnect_nodes(from_node: String, from_slot: int, to_node: String, to_slot: int = 0) -> void</div>
+      <p class="method-desc">Elimina una conexión específica.</p>
+
+      <div class="method-signature">func get_next_nodes(node_id: String, slot: int = 0) -> Array[DialogueNodeData]</div>
+      <p class="method-desc">Obtiene los nodos siguientes desde un slot de salida.</p>
+
+      <div class="method-signature">func get_next_node(node_id: String, slot: int = 0) -> DialogueNodeData</div>
+      <p class="method-desc">Obtiene el siguiente nodo (para flujo lineal).</p>
+
+      <h4>Validación</h4>
+
+      <div class="method-signature">func validate() -> Array[String]</div>
+      <p class="method-desc">Valida la estructura del grafo. Retorna array de errores.</p>
+
+      <h3>Ejemplo de Uso</h3>
+
+      <pre data-lang="GDSCRIPT"><code># Crear grafo programáticamente
+var graph = DialogueGraph.new()
+graph.graph_id = "merchant_greeting"
+graph.display_name = "Saludo del Mercader"
+graph.default_character = preload("res://npcs/merchant.tres")
+graph.world_context = preload("res://world/fantasy.tres")
+
+# Crear nodos
+var start = graph.create_node(DialogueNodeData.NodeType.START)
+var greeting = graph.create_node(DialogueNodeData.NodeType.AI_RESPONSE, Vector2(200, 0))
+greeting.data.character_id = "merchant_grok"
+greeting.data.prompt_template = "Saluda al cliente que acaba de entrar a tu tienda."
+
+var choice = graph.create_node(DialogueNodeData.NodeType.PLAYER_CHOICE, Vector2(400, 0))
+choice.data.choices = [
+    {"text": "¿Qué vendes?", "condition": ""},
+    {"text": "Adiós", "condition": ""}
+]
+
+var end_node = graph.create_node(DialogueNodeData.NodeType.END, Vector2(600, 100))
+
+# Conectar nodos
+graph.connect_nodes(start.node_id, 0, greeting.node_id)
+graph.connect_nodes(greeting.node_id, 0, choice.node_id)
+graph.connect_nodes(choice.node_id, 1, end_node.node_id)  # "Adiós" -> End
+
+# Validar
+var errors = graph.validate()
+if errors.is_empty():
+    print("Grafo válido!")
+else:
+    for err in errors:
+        push_error(err)
+
+# Guardar como resource
+ResourceSaver.save(graph, "res://dialogues/merchant_greeting.tres")</code></pre>
+
+      <hr>
+
       <h2>Próximamente</h2>
 
       <p>Estos Resources están planificados pero aún no implementados:</p>
@@ -590,11 +785,6 @@ var context = world.to_context_prompt()</code></pre>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><code>DialogueGraph</code></td>
-            <td>Grafo completo de nodos de diálogo</td>
-            <td><a href="https://github.com/lobinuxsoft/OhMyDialogSystem/issues/142">#142</a></td>
-          </tr>
           <tr>
             <td><code>AIPreset</code></td>
             <td>Configuración de parámetros de generación</td>


### PR DESCRIPTION
## Summary
- Recurso que contiene un grafo completo de diálogo
- Gestión de nodos y conexiones con signals
- Validación de estructura (nodos huérfanos, dead ends, etc.)
- Soporte para sistema híbrido (scripted + free mode)

## Cambios
- `addons/ohmydialog/resources/dialogue_graph.gd` - Resource principal (400+ líneas)
- `addons/ohmydialog/icons/dialogue_graph.svg` - Icono de nodos conectados
- `docs/API/resources.html` - Documentación completa agregada

## Características
- Referencias a CharacterIdentity y WorldContext
- Signals para cambios en el grafo
- Métodos: `add_node`, `create_node`, `connect_nodes`, `get_next_nodes`
- Validación completa con `validate()`
- Duplicación de grafos con `duplicate_graph()`

## Test plan
- [ ] Crear DialogueGraph en el Inspector
- [ ] Agregar nodos programáticamente
- [ ] Conectar nodos y verificar conexiones
- [ ] Validar grafo y revisar errores

Closes #142