### PR TITLE
feat(gdextension): agregar signals async en LlamaInterface

### DIFF
--- a/gdextension/src/llama_interface.cpp
+++ b/gdextension/src/llama_interface.cpp
@@ -120,8 +120,18 @@ void LlamaInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_timeout"), &LlamaInterface::get_timeout);
 	ClassDB::bind_method(D_METHOD("has_generation_timed_out"), &LlamaInterface::has_generation_timed_out);
 
+	// Async generation status
+	ClassDB::bind_method(D_METHOD("is_generating"), &LlamaInterface::is_generating);
+	ClassDB::bind_method(D_METHOD("get_generation_progress"), &LlamaInterface::get_generation_progress);
+
 	// Signals
 	ADD_SIGNAL(MethodInfo("generation_timeout"));
+	ADD_SIGNAL(MethodInfo("generation_started"));
+	ADD_SIGNAL(MethodInfo("token_generated", PropertyInfo(Variant::STRING, "token")));
+	ADD_SIGNAL(MethodInfo("generation_completed", PropertyInfo(Variant::STRING, "response")));
+	ADD_SIGNAL(MethodInfo("generation_error", PropertyInfo(Variant::STRING, "error")));
+	ADD_SIGNAL(MethodInfo("generation_progress", PropertyInfo(Variant::FLOAT, "progress")));
+	ADD_SIGNAL(MethodInfo("generation_cancelled"));
 
 	// Properties
 	ADD_GROUP("Sampling", "");
@@ -535,6 +545,20 @@ int64_t LlamaInterface::get_timeout() const {
 
 bool LlamaInterface::has_generation_timed_out() const {
 	return m_generation_timed_out;
+}
+
+// ==================== Async Generation Status ====================
+
+bool LlamaInterface::is_generating() const {
+	return m_is_generating.load();
+}
+
+float LlamaInterface::get_generation_progress() const {
+	if (!m_is_generating.load() || m_max_tokens <= 0) {
+		return 0.0f;
+	}
+	int tokens = m_tokens_generated.load();
+	return static_cast<float>(tokens) / static_cast<float>(m_max_tokens);
 }
 
 } // namespace godot

--- a/gdextension/src/llama_interface.h
+++ b/gdextension/src/llama_interface.h
@@ -2,12 +2,14 @@
 #define LLAMA_INTERFACE_H
 
 #include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/classes/worker_thread_pool.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/string.hpp>
 
 #include "llama.h"
 
+#include <atomic>
 #include <chrono>
 #include <string>
 #include <vector>
@@ -44,6 +46,12 @@ private:
 	// Timeout configuration
 	int64_t m_timeout_ms = 0; // 0 = no timeout
 	bool m_generation_timed_out = false;
+
+	// Async generation state
+	std::atomic<bool> m_is_generating{false};
+	std::atomic<bool> m_cancel_requested{false};
+	std::atomic<int> m_tokens_generated{0};
+	WorkerThreadPool::TaskID m_current_task_id = WorkerThreadPool::INVALID_TASK_ID;
 
 	// Internal methods
 	void _cleanup();
@@ -146,6 +154,16 @@ public:
 
 	/// Check if the last generation timed out
 	bool has_generation_timed_out() const;
+
+	// ==================== Async Generation Status ====================
+
+	/// Check if generation is currently in progress
+	/// @return true if generating, false otherwise
+	bool is_generating() const;
+
+	/// Get the progress of current generation (0.0 to 1.0)
+	/// @return tokens_generated / max_tokens
+	float get_generation_progress() const;
 };
 
 } // namespace godot


### PR DESCRIPTION
## Summary
- Agregar includes para `<atomic>` y `worker_thread_pool.hpp`
- Agregar miembros atómicos: `m_is_generating`, `m_cancel_requested`, `m_tokens_generated`
- Agregar signals: `generation_started`, `token_generated`, `generation_completed`, `generation_error`, `generation_progress`, `generation_cancelled`
- Implementar `is_generating()` y `get_generation_progress()`

## Test plan
- [ ] Verificar que compila sin errores
- [ ] Verificar que los signals están disponibles en GDScript

Closes #160