### PR TITLE
feat(editor): implementar AI Dock panel lateral

### DIFF
--- a/addons/ohmydialog/editor/ai_dock.gd
+++ b/addons/ohmydialog/editor/ai_dock.gd
@@ -1,0 +1,119 @@
+@tool
+class_name AIDock
+extends Control
+## Compact dock panel for AI status and controls in the editor.
+##
+## Shows current model status and provides quick access to load/unload
+## and configuration options.
+
+## Emitted when user requests to open config dialog
+signal config_requested()
+
+## Emitted when user requests to load a model (no model loaded)
+signal load_requested()
+
+## UI References
+@onready var _status_icon: TextureRect = %StatusIcon
+@onready var _status_label: Label = %StatusLabel
+@onready var _model_label: Label = %ModelLabel
+@onready var _action_button: Button = %ActionButton
+@onready var _config_button: Button = %ConfigButton
+
+var _ai_service: AIService
+
+
+func _ready() -> void:
+	_action_button.pressed.connect(_on_action_pressed)
+	_config_button.pressed.connect(_on_config_pressed)
+
+	# Defer connection to AIService to ensure it's initialized
+	call_deferred("_connect_ai_service")
+
+
+func _connect_ai_service() -> void:
+	_ai_service = AIService.get_singleton()
+
+	if _ai_service:
+		_ai_service.model_loaded.connect(_on_model_loaded)
+		_ai_service.model_unloaded.connect(_on_model_unloaded)
+		_update_ui()
+	else:
+		push_warning("AIDock: AIService not available")
+		_set_disconnected_state()
+
+
+func _update_ui() -> void:
+	if not _ai_service:
+		_set_disconnected_state()
+		return
+
+	if _ai_service.is_model_loaded():
+		_set_loaded_state()
+	else:
+		_set_unloaded_state()
+
+
+func _set_loaded_state() -> void:
+	_status_label.text = "Model Loaded"
+	_status_label.add_theme_color_override("font_color", Color.GREEN)
+
+	var config = _ai_service.get_current_config()
+	if config:
+		_model_label.text = config.display_name
+	else:
+		_model_label.text = "Unknown Model"
+	_model_label.visible = true
+
+	_action_button.text = "Unload"
+	_action_button.icon = get_theme_icon("Stop", "EditorIcons")
+
+	_status_icon.modulate = Color.GREEN
+
+
+func _set_unloaded_state() -> void:
+	_status_label.text = "No Model"
+	_status_label.add_theme_color_override("font_color", Color.GRAY)
+
+	_model_label.text = ""
+	_model_label.visible = false
+
+	_action_button.text = "Load"
+	_action_button.icon = get_theme_icon("Play", "EditorIcons")
+
+	_status_icon.modulate = Color.GRAY
+
+
+func _set_disconnected_state() -> void:
+	_status_label.text = "Disconnected"
+	_status_label.add_theme_color_override("font_color", Color.RED)
+
+	_model_label.text = ""
+	_model_label.visible = false
+
+	_action_button.text = "Retry"
+	_action_button.icon = get_theme_icon("Reload", "EditorIcons")
+
+	_status_icon.modulate = Color.RED
+
+
+func _on_action_pressed() -> void:
+	if not _ai_service:
+		_connect_ai_service()
+		return
+
+	if _ai_service.is_model_loaded():
+		_ai_service.unload_model()
+	else:
+		load_requested.emit()
+
+
+func _on_config_pressed() -> void:
+	config_requested.emit()
+
+
+func _on_model_loaded(_config: ModelConfig) -> void:
+	_update_ui()
+
+
+func _on_model_unloaded() -> void:
+	_update_ui()

--- a/addons/ohmydialog/editor/ai_dock.tscn
+++ b/addons/ohmydialog/editor/ai_dock.tscn
@@ -1,0 +1,81 @@
+[gd_scene load_steps=2 format=3 uid="uid://c4ai_dock_panel"]
+
+[ext_resource type="Script" path="res://addons/ohmydialog/editor/ai_dock.gd" id="1_script"]
+
+[node name="AIDock" type="Control"]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_script")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 8
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Header" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="StatusIcon" type="TextureRect" parent="MarginContainer/VBoxContainer/Header"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(16, 16)
+layout_mode = 2
+size_flags_vertical = 4
+stretch_mode = 5
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer/Header"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "AI Status"
+theme_type_variation = &"HeaderSmall"
+
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="StatusContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="StatusLabel" type="Label" parent="MarginContainer/VBoxContainer/StatusContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "No Model"
+
+[node name="ModelLabel" type="Label" parent="MarginContainer/VBoxContainer/StatusContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_type_variation = &"HeaderSmall"
+text = "Model Name"
+
+[node name="ButtonContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 8
+theme_override_constants/separation = 8
+
+[node name="ActionButton" type="Button" parent="MarginContainer/VBoxContainer/ButtonContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Load"
+
+[node name="ConfigButton" type="Button" parent="MarginContainer/VBoxContainer/ButtonContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(32, 0)
+layout_mode = 2
+tooltip_text = "AI Configuration"

--- a/addons/ohmydialog/plugin.gd
+++ b/addons/ohmydialog/plugin.gd
@@ -15,6 +15,9 @@ var _inspector_plugin: DialogueNodeInspectorPlugin
 ## Reference to the AI service singleton.
 var _ai_service: AIService
 
+## Reference to the AI dock panel.
+var _ai_dock: AIDock
+
 
 func _enter_tree() -> void:
 	# Initialize AI service singleton first
@@ -36,6 +39,13 @@ func _enter_tree() -> void:
 	# Add as bottom panel (more space for graph editing than dock)
 	add_control_to_bottom_panel(_editor_instance, "Dialogue Graph")
 
+	# Initialize AI dock panel
+	var dock_scene := preload("res://addons/ohmydialog/editor/ai_dock.tscn")
+	_ai_dock = dock_scene.instantiate()
+	_ai_dock.config_requested.connect(_on_ai_config_requested)
+	_ai_dock.load_requested.connect(_on_ai_load_requested)
+	add_control_to_dock(DOCK_SLOT_RIGHT_UL, _ai_dock)
+
 	print("OhMyDialogSystem: Plugin loaded")
 
 
@@ -50,6 +60,12 @@ func _exit_tree() -> void:
 		remove_control_from_bottom_panel(_editor_instance)
 		_editor_instance.queue_free()
 		_editor_instance = null
+
+	# Clean up AI dock
+	if _ai_dock:
+		remove_control_from_docks(_ai_dock)
+		_ai_dock.queue_free()
+		_ai_dock = null
 
 	# Clean up AI service
 	if _ai_service:
@@ -82,3 +98,15 @@ func _make_visible(visible: bool) -> void:
 	if _editor_instance:
 		if visible:
 			make_bottom_panel_item_visible(_editor_instance)
+
+
+## Called when user requests AI configuration from dock.
+func _on_ai_config_requested() -> void:
+	# TODO: Open AI Config Dialog (issue #167)
+	print("OhMyDialogSystem: Config requested - dialog not implemented yet")
+
+
+## Called when user requests to load a model from dock.
+func _on_ai_load_requested() -> void:
+	# TODO: Open Model Required Dialog (issue #166)
+	print("OhMyDialogSystem: Load requested - dialog not implemented yet")


### PR DESCRIPTION
## Summary
- Panel lateral compacto para controlar estado de IA en el editor
- Muestra estado del modelo (loaded/unloaded)
- Botones para Load/Unload y Config

## Cambios
- `addons/ohmydialog/editor/ai_dock.gd` - Lógica del panel
- `addons/ohmydialog/editor/ai_dock.tscn` - UI del dock
- `addons/ohmydialog/plugin.gd` - Registro del dock

## UI
```
┌─────────────────┐
│ 🤖 AI Status    │
├─────────────────┤
│ ✓ Model Loaded  │
│ Qwen2.5 3B Q4   │
│                 │
│ [Unload] [⚙️]   │
└─────────────────┘
```

## Pendiente
- Dialogs serán implementados en #166 y #167

Closes #165