### PR TITLE
feat(editor): implementar ModelRequiredDialog

### DIFF
--- a/addons/ohmydialog/editor/model_required_dialog.gd
+++ b/addons/ohmydialog/editor/model_required_dialog.gd
@@ -25,8 +25,7 @@ var _downloaded_models: Array[ModelConfig] = []
 
 func _init() -> void:
 	title = "Modelo de IA Requerido"
-	size = Vector2i(400, 200)
-	unresizable = true
+	unresizable = false
 
 
 func _ready() -> void:
@@ -38,6 +37,7 @@ func _ready() -> void:
 func _setup_ui() -> void:
 	_content_container = VBoxContainer.new()
 	_content_container.add_theme_constant_override("separation", 12)
+	_content_container.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
 	add_child(_content_container)
 
 	# Message label (shown in both modes)
@@ -90,6 +90,19 @@ func _connect_ai_service() -> void:
 func show_dialog() -> void:
 	_refresh_models()
 	_update_ui()
+
+	# Calculate size as 25% of screen
+	var screen_size := DisplayServer.screen_get_size()
+	var dialog_size := Vector2i(int(screen_size.x * 0.25), int(screen_size.y * 0.25))
+
+	# Clip content to prevent overflow
+	_content_container.clip_contents = true
+
+	# Force dialog size
+	reset_size()
+	min_size = dialog_size
+	max_size = dialog_size
+	size = dialog_size
 	popup_centered()
 
 

--- a/addons/ohmydialog/editor/model_required_dialog.tscn
+++ b/addons/ohmydialog/editor/model_required_dialog.tscn
@@ -5,6 +5,4 @@
 [node name="ModelRequiredDialog" type="ConfirmationDialog"]
 title = "Modelo de IA Requerido"
 initial_position = 2
-size = Vector2i(400, 200)
-unresizable = true
 script = ExtResource("1_script")

--- a/addons/ohmydialog/plugin.gd
+++ b/addons/ohmydialog/plugin.gd
@@ -20,6 +20,9 @@ var _ai_service: AIService
 ## Reference to the AI dock panel.
 var _ai_dock: AIDock
 
+## Reference to the model required dialog.
+var _model_required_dialog: ModelRequiredDialog
+
 
 func _enter_tree() -> void:
 	# Register AutoLoad for runtime (automatic, user doesn't need to configure)
@@ -52,6 +55,13 @@ func _enter_tree() -> void:
 	_ai_dock.load_requested.connect(_on_ai_load_requested)
 	add_control_to_dock(DOCK_SLOT_RIGHT_UL, _ai_dock)
 
+	# Initialize model required dialog
+	var dialog_scene := preload("res://addons/ohmydialog/editor/model_required_dialog.tscn")
+	_model_required_dialog = dialog_scene.instantiate()
+	_model_required_dialog.open_model_manager_requested.connect(_on_open_model_manager_requested)
+	_model_required_dialog.model_activated.connect(_on_model_activated)
+	EditorInterface.get_base_control().add_child(_model_required_dialog)
+
 	print("OhMyDialogSystem: Plugin loaded")
 
 
@@ -77,6 +87,11 @@ func _exit_tree() -> void:
 	if _ai_service:
 		_ai_service.queue_free()
 		_ai_service = null
+
+	# Clean up model required dialog
+	if _model_required_dialog:
+		_model_required_dialog.queue_free()
+		_model_required_dialog = null
 
 	# Note: We don't unregister the autoload here because:
 	# 1. It would break running games if user disables plugin while testing
@@ -129,5 +144,16 @@ func _on_ai_config_requested() -> void:
 
 ## Called when user requests to load a model from dock.
 func _on_ai_load_requested() -> void:
-	# TODO: Open Model Required Dialog (issue #166)
-	print("OhMyDialogSystem: Load requested - dialog not implemented yet")
+	if _model_required_dialog:
+		_model_required_dialog.show_dialog()
+
+
+## Called when user requests to open the Model Manager from the dialog.
+func _on_open_model_manager_requested() -> void:
+	# TODO: Open Model Manager window (future implementation)
+	print("OhMyDialogSystem: Model Manager not implemented yet")
+
+
+## Called when a model is activated from the dialog.
+func _on_model_activated(config: ModelConfig) -> void:
+	print("OhMyDialogSystem: Model activated - %s" % config.display_name)


### PR DESCRIPTION
## Summary
- Integración completa de ModelRequiredDialog en el plugin principal
- El diálogo se muestra desde AIDock al presionar "Load" sin modelo cargado
- Tamaño dinámico (25% de pantalla) para adaptarse a diferentes resoluciones
- Arreglado bug de expansión infinita del contenedor

## Cambios
- `plugin.gd`: Instanciar diálogo, conectar señales, handlers
- `model_required_dialog.gd`: Tamaño dinámico, clip_contents para evitar overflow
- `model_required_dialog.tscn`: Limpieza de propiedades hardcodeadas

## Test plan
- [x] Abrir editor con plugin activo
- [x] En AIDock, presionar "Load" sin modelo cargado
- [x] Verificar que el diálogo aparece centrado con tamaño correcto
- [x] Si hay modelos descargados: verificar dropdown y botón "Activar"
- [x] Si no hay modelos: verificar mensaje y botón "Ir al Gestor"

Closes #166