### PR TITLE
feat(editor): exponer variables de test y ocultar RETURN_TO_GRAPH

### DIFF
--- a/Test dialogue.tres
+++ b/Test dialogue.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="DialogueGraph" load_steps=4 format=3 uid="uid://da1u03s4aooij"]
+
+[ext_resource type="Script" uid="uid://reckn0fl8oqw" path="res://addons/ohmydialog/resources/nodes/start_node_data.gd" id="1_vxwv8"]
+[ext_resource type="Script" uid="uid://bltsjidn3ba3t" path="res://addons/ohmydialog/resources/dialogue_graph.gd" id="2_2lfw8"]
+
+[sub_resource type="Resource" id="Resource_xqr30"]
+script = ExtResource("1_vxwv8")
+node_id = "3b8d6f5e-8dda-418e-9f27-25681a6e605c"
+editor_position = Vector2(100, 200)
+
+[resource]
+script = ExtResource("2_2lfw8")
+graph_id = "graph_1769368502"
+display_name = "New Dialogue"
+nodes = {
+"3b8d6f5e-8dda-418e-9f27-25681a6e605c": SubResource("Resource_xqr30")
+}
+start_node_id = "3b8d6f5e-8dda-418e-9f27-25681a6e605c"

--- a/addons/ohmydialog/editor/dialogue_graph_editor.gd
+++ b/addons/ohmydialog/editor/dialogue_graph_editor.gd
@@ -114,6 +114,9 @@ func _setup_toolbar() -> void:
 	popup.clear()
 
 	for i in DialogueNodeData.NodeType.size():
+		# Skip internal-only nodes (RETURN_TO_GRAPH is handled internally by JUMP_TO_FREE)
+		if i == DialogueNodeData.NodeType.RETURN_TO_GRAPH:
+			continue
 		var type_name := DialogueNodeData.get_type_name_static(i)
 		popup.add_item(type_name, i)
 		# Add icon color indicator
@@ -129,6 +132,9 @@ func _setup_context_menu() -> void:
 	# Add Node submenu
 	add_node_submenu.clear()
 	for i in DialogueNodeData.NodeType.size():
+		# Skip internal-only nodes (RETURN_TO_GRAPH is handled internally by JUMP_TO_FREE)
+		if i == DialogueNodeData.NodeType.RETURN_TO_GRAPH:
+			continue
 		var type_name := DialogueNodeData.get_type_name_static(i)
 		add_node_submenu.add_item(type_name, i)
 	add_node_submenu.id_pressed.connect(_on_add_node_submenu_id_pressed)

--- a/examples/dialogue_test_scene.gd
+++ b/examples/dialogue_test_scene.gd
@@ -18,14 +18,15 @@ extends Control
 
 var dialogue_manager: DialogueManager
 
+# Test configuration - set these in the Inspector
+@export_group("Test Resources")
+@export var test_character: CharacterIdentity
+@export var test_world: WorldContext
+@export var test_dialogue: DialogueGraph
+
 # Debug tracking
 var last_player_input: String = ""
 var pending_choices: Array[Dictionary] = []
-
-# Resources
-var merchant_character: CharacterIdentity
-var fantasy_world: WorldContext
-var merchant_dialogue: DialogueGraph
 
 
 func _ready() -> void:
@@ -55,14 +56,18 @@ func _check_ai_service() -> void:
 
 
 func _load_resources() -> void:
-	merchant_character = load("res://examples/resources/merchant_character.tres")
-	fantasy_world = load("res://examples/resources/fantasy_world.tres")
-	merchant_dialogue = load("res://examples/resources/merchant_dialogue.tres")
+	# Use exported resources if set, otherwise load defaults
+	if not test_character:
+		test_character = load("res://examples/resources/merchant_character.tres")
+	if not test_world:
+		test_world = load("res://examples/resources/fantasy_world.tres")
+	if not test_dialogue:
+		test_dialogue = load("res://examples/resources/merchant_dialogue.tres")
 
-	if merchant_character:
-		dialogue_manager.default_character = merchant_character
-	if fantasy_world:
-		dialogue_manager.world_context = fantasy_world
+	if test_character:
+		dialogue_manager.default_character = test_character
+	if test_world:
+		dialogue_manager.world_context = test_world
 	# Note: ai_preset is now set on DialogueGraph, not DialogueManager
 
 
@@ -187,8 +192,8 @@ func _update_debug() -> void:
 
 
 func _on_start_pressed() -> void:
-	if merchant_dialogue:
-		dialogue_manager.start_dialogue(merchant_dialogue, DialogueManager.DialogueMode.SCRIPTED)
+	if test_dialogue:
+		dialogue_manager.start_dialogue(test_dialogue, DialogueManager.DialogueMode.SCRIPTED)
 	else:
 		push_error("No dialogue graph loaded!")
 

--- a/examples/dialogue_test_scene.tscn
+++ b/examples/dialogue_test_scene.tscn
@@ -1,6 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://bvirxw54wgi03"]
+[gd_scene load_steps=5 format=3 uid="uid://bvirxw54wgi03"]
 
 [ext_resource type="Script" uid="uid://poksx1f252dk" path="res://examples/dialogue_test_scene.gd" id="1"]
+[ext_resource type="Resource" uid="uid://cmq5w2y3jwple" path="res://examples/resources/merchant_character.tres" id="2_hk1sm"]
+[ext_resource type="Resource" path="res://examples/resources/fantasy_world.tres" id="3_kk6dh"]
+[ext_resource type="Resource" uid="uid://c2vjxlm7hk8qr" path="res://examples/resources/tests/test_02_jump_target.tres" id="4_hk1sm"]
 
 [node name="DialogueTestScene" type="Control"]
 layout_mode = 3
@@ -10,6 +13,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1")
+test_character = ExtResource("2_hk1sm")
+test_world = ExtResource("3_kk6dh")
+test_dialogue = ExtResource("4_hk1sm")
 
 [node name="Background" type="ColorRect" parent="."]
 layout_mode = 1

--- a/examples/resources/Test_scene.tres
+++ b/examples/resources/Test_scene.tres
@@ -1,0 +1,34 @@
+[gd_resource type="Resource" script_class="DialogueGraph" load_steps=9 format=3 uid="uid://dhtlwv8f6ae6u"]
+
+[ext_resource type="Script" uid="uid://reckn0fl8oqw" path="res://addons/ohmydialog/resources/nodes/start_node_data.gd" id="1_0m3as"]
+[ext_resource type="Resource" uid="uid://ck3pm0u53hrr6" path="res://presets/qwen2.5_3b_instruct_q4_preset.tres" id="1_2jfb3"]
+[ext_resource type="Resource" uid="uid://cmq5w2y3jwple" path="res://examples/resources/merchant_character.tres" id="2_c7q4t"]
+[ext_resource type="Script" uid="uid://bltsjidn3ba3t" path="res://addons/ohmydialog/resources/dialogue_graph.gd" id="2_eu15q"]
+[ext_resource type="Script" uid="uid://o4cv1xthgph0" path="res://addons/ohmydialog/resources/nodes/jump_node_data.gd" id="4_5ml0p"]
+[ext_resource type="Resource" path="res://examples/resources/fantasy_world.tres" id="6_r4djo"]
+
+[sub_resource type="Resource" id="Resource_5hw8e"]
+script = ExtResource("1_0m3as")
+node_id = "2989bb7f-2c82-482d-8bcc-5382702584df"
+editor_position = Vector2(100, 200)
+
+[sub_resource type="Resource" id="Resource_5dq8g"]
+script = ExtResource("4_5ml0p")
+target_graph_id = "uid://i1sbtg72xp43"
+node_id = "5d7668ef-c80b-4f50-a62f-1ff6e2b133f1"
+editor_position = Vector2(420, 140)
+output_count = 0
+
+[resource]
+script = ExtResource("2_eu15q")
+graph_id = "graph_1769365731"
+display_name = "New Dialogue"
+default_character = ExtResource("2_c7q4t")
+world_context = ExtResource("6_r4djo")
+ai_preset = ExtResource("1_2jfb3")
+model_path = "res://models/qwen2.5-3b-instruct-q4_k_m.gguf"
+nodes = {
+"2989bb7f-2c82-482d-8bcc-5382702584df": SubResource("Resource_5hw8e"),
+"5d7668ef-c80b-4f50-a62f-1ff6e2b133f1": SubResource("Resource_5dq8g")
+}
+start_node_id = "2989bb7f-2c82-482d-8bcc-5382702584df"

--- a/examples/resources/tests/test_01_basic_flow.tres
+++ b/examples/resources/tests/test_01_basic_flow.tres
@@ -1,0 +1,206 @@
+[gd_resource type="Resource" script_class="DialogueGraph" load_steps=24 format=3 uid="uid://dhayneqkgak6r"]
+
+[ext_resource type="Script" uid="uid://bltsjidn3ba3t" path="res://addons/ohmydialog/resources/dialogue_graph.gd" id="1_graph"]
+[ext_resource type="Resource" uid="uid://ck3pm0u53hrr6" path="res://presets/qwen2.5_3b_instruct_q4_preset.tres" id="1_oldl7"]
+[ext_resource type="Script" uid="uid://reckn0fl8oqw" path="res://addons/ohmydialog/resources/nodes/start_node_data.gd" id="2_start"]
+[ext_resource type="Resource" uid="uid://cmq5w2y3jwple" path="res://examples/resources/merchant_character.tres" id="2_yksww"]
+[ext_resource type="Script" uid="uid://crtfmbxjvqyo2" path="res://addons/ohmydialog/resources/nodes/static_response_node_data.gd" id="4_static"]
+[ext_resource type="Script" uid="uid://cqyrip3w786hr" path="res://addons/ohmydialog/resources/nodes/player_choice_node_data.gd" id="5_choice"]
+[ext_resource type="Script" uid="uid://5ea8tirgd5bk" path="res://addons/ohmydialog/resources/nodes/condition_node_data.gd" id="6_condition"]
+[ext_resource type="Script" uid="uid://d10r24nxqwapt" path="res://addons/ohmydialog/resources/nodes/set_variable_node_data.gd" id="7_setvar"]
+[ext_resource type="Script" uid="uid://cghxg1us5y4mm" path="res://addons/ohmydialog/resources/nodes/event_node_data.gd" id="8_event"]
+[ext_resource type="Script" uid="uid://o4cv1xthgph0" path="res://addons/ohmydialog/resources/nodes/jump_node_data.gd" id="9_oldl7"]
+[ext_resource type="Resource" path="res://examples/resources/fantasy_world.tres" id="11_7qtcy"]
+
+[sub_resource type="Resource" id="node_start"]
+script = ExtResource("2_start")
+node_id = "start"
+editor_position = Vector2(0, 200)
+
+[sub_resource type="Resource" id="node_welcome"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "Bienvenido al test de flujo basico. Elige una opcion."
+emotion = "neutral"
+node_id = "welcome"
+editor_position = Vector2(250, 200)
+
+[sub_resource type="Resource" id="node_choice"]
+script = ExtResource("5_choice")
+choices = PackedStringArray("Probar Condition (true)", "Probar Condition (false)", "Ir directo al final")
+node_id = "main_choice"
+editor_position = Vector2(550, 200)
+output_count = 3
+
+[sub_resource type="Resource" id="node_set_high"]
+script = ExtResource("7_setvar")
+variable = "test_value"
+value = 100
+node_id = "set_high"
+editor_position = Vector2(850, 50)
+
+[sub_resource type="Resource" id="node_set_low"]
+script = ExtResource("7_setvar")
+variable = "test_value"
+value = 10
+node_id = "set_low"
+editor_position = Vector2(850, 200)
+
+[sub_resource type="Resource" id="node_condition"]
+script = ExtResource("6_condition")
+variable = "test_value"
+operator = 3
+value = 50
+node_id = "check_value"
+editor_position = Vector2(1150, 125)
+output_count = 2
+
+[sub_resource type="Resource" id="node_event_pass"]
+script = ExtResource("8_event")
+event_name = "test_passed"
+event_data = {
+"result": "condition_true",
+"value": 100
+}
+node_id = "event_pass"
+editor_position = Vector2(1450, 50)
+
+[sub_resource type="Resource" id="node_event_fail"]
+script = ExtResource("8_event")
+event_name = "test_failed"
+event_data = {
+"result": "condition_false",
+"value": 10
+}
+node_id = "event_fail"
+editor_position = Vector2(1450, 200)
+
+[sub_resource type="Resource" id="node_result_pass"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "PASSED: Condition evaluo TRUE correctamente (valor >= 50)"
+emotion = "happy"
+node_id = "result_pass"
+editor_position = Vector2(1740, -20)
+
+[sub_resource type="Resource" id="node_result_fail"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "PASSED: Condition evaluo FALSE correctamente (valor < 50)"
+emotion = "neutral"
+node_id = "result_fail"
+editor_position = Vector2(1750, 200)
+
+[sub_resource type="Resource" id="node_skip"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "Saltaste directamente al final. PlayerChoice funciona."
+emotion = "neutral"
+node_id = "skip_msg"
+editor_position = Vector2(850, 350)
+
+[sub_resource type="Resource" id="Resource_yksww"]
+script = ExtResource("9_oldl7")
+target_graph_id = "uid://c2vjxlm7hk8qr"
+node_id = "f0916ff3-55bb-4ec6-b8c8-6c714a977704"
+editor_position = Vector2(2080, 400)
+output_count = 0
+
+[resource]
+script = ExtResource("1_graph")
+graph_id = "test_basic_flow"
+display_name = "Test 01: Flujo Basico"
+description = "Prueba START, STATIC_RESPONSE, PLAYER_CHOICE, SET_VARIABLE, CONDITION, EVENT, END"
+default_character = ExtResource("2_yksww")
+world_context = ExtResource("11_7qtcy")
+ai_preset = ExtResource("1_oldl7")
+model_path = "res://models/qwen2.5-3b-instruct-q4_k_m.gguf"
+local_variables = {
+"test_value": 0
+}
+nodes = {
+"check_value": SubResource("node_condition"),
+"event_fail": SubResource("node_event_fail"),
+"event_pass": SubResource("node_event_pass"),
+"f0916ff3-55bb-4ec6-b8c8-6c714a977704": SubResource("Resource_yksww"),
+"main_choice": SubResource("node_choice"),
+"result_fail": SubResource("node_result_fail"),
+"result_pass": SubResource("node_result_pass"),
+"set_high": SubResource("node_set_high"),
+"set_low": SubResource("node_set_low"),
+"skip_msg": SubResource("node_skip"),
+"start": SubResource("node_start"),
+"welcome": SubResource("node_welcome")
+}
+connections = Array[Dictionary]([{
+"from_node": "start",
+"from_slot": 0,
+"to_node": "welcome",
+"to_slot": 0
+}, {
+"from_node": "welcome",
+"from_slot": 0,
+"to_node": "main_choice",
+"to_slot": 0
+}, {
+"from_node": "main_choice",
+"from_slot": 0,
+"to_node": "set_high",
+"to_slot": 0
+}, {
+"from_node": "main_choice",
+"from_slot": 1,
+"to_node": "set_low",
+"to_slot": 0
+}, {
+"from_node": "main_choice",
+"from_slot": 2,
+"to_node": "skip_msg",
+"to_slot": 0
+}, {
+"from_node": "set_high",
+"from_slot": 0,
+"to_node": "check_value",
+"to_slot": 0
+}, {
+"from_node": "set_low",
+"from_slot": 0,
+"to_node": "check_value",
+"to_slot": 0
+}, {
+"from_node": "check_value",
+"from_slot": 0,
+"to_node": "event_pass",
+"to_slot": 0
+}, {
+"from_node": "check_value",
+"from_slot": 1,
+"to_node": "event_fail",
+"to_slot": 0
+}, {
+"from_node": "event_pass",
+"from_slot": 0,
+"to_node": "result_pass",
+"to_slot": 0
+}, {
+"from_node": "event_fail",
+"from_slot": 0,
+"to_node": "result_fail",
+"to_slot": 0
+}, {
+"from_node": "result_pass",
+"from_slot": 0,
+"to_node": "f0916ff3-55bb-4ec6-b8c8-6c714a977704",
+"to_slot": 0
+}, {
+"from_node": "result_fail",
+"from_slot": 0,
+"to_node": "f0916ff3-55bb-4ec6-b8c8-6c714a977704",
+"to_slot": 0
+}, {
+"from_node": "skip_msg",
+"from_slot": 0,
+"to_node": "f0916ff3-55bb-4ec6-b8c8-6c714a977704",
+"to_slot": 0
+}])
+start_node_id = "start"

--- a/examples/resources/tests/test_02_jump_target.tres
+++ b/examples/resources/tests/test_02_jump_target.tres
@@ -1,0 +1,115 @@
+[gd_resource type="Resource" script_class="DialogueGraph" load_steps=13 format=3 uid="uid://c2vjxlm7hk8qr"]
+
+[ext_resource type="Script" uid="uid://bltsjidn3ba3t" path="res://addons/ohmydialog/resources/dialogue_graph.gd" id="1_graph"]
+[ext_resource type="Script" uid="uid://reckn0fl8oqw" path="res://addons/ohmydialog/resources/nodes/start_node_data.gd" id="2_start"]
+[ext_resource type="Script" uid="uid://csx5x0eq6vwvk" path="res://addons/ohmydialog/resources/nodes/end_node_data.gd" id="3_end"]
+[ext_resource type="Script" uid="uid://crtfmbxjvqyo2" path="res://addons/ohmydialog/resources/nodes/static_response_node_data.gd" id="4_static"]
+[ext_resource type="Script" uid="uid://cqyrip3w786hr" path="res://addons/ohmydialog/resources/nodes/player_choice_node_data.gd" id="5_choice"]
+[ext_resource type="Script" uid="uid://c4akvhu8851x2" path="res://addons/ohmydialog/resources/nodes/jump_to_free_node_data.gd" id="6_free"]
+
+[sub_resource type="Resource" id="node_start"]
+script = ExtResource("2_start")
+node_id = "start"
+editor_position = Vector2(0, 200)
+
+[sub_resource type="Resource" id="node_arrived"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "Has llegado al GRAFO 2 mediante JUMP. El salto funciono correctamente."
+emotion = "happy"
+node_id = "arrived"
+editor_position = Vector2(300, 200)
+
+[sub_resource type="Resource" id="node_choice"]
+script = ExtResource("5_choice")
+choices = PackedStringArray("Probar JUMP_TO_FREE (modo libre)", "Info sobre RETURN_TO_GRAPH", "Terminar aqui con END")
+node_id = "mode_choice"
+editor_position = Vector2(650, 200)
+output_count = 3
+
+[sub_resource type="Resource" id="node_free"]
+script = ExtResource("6_free")
+context_prompt = "Eres un asistente de pruebas en modo conversacion libre. Responde brevemente. Cuando el usuario diga 'salir', 'volver' o 'exit', despidete."
+return_keywords = PackedStringArray("salir", "volver", "exit")
+max_exchanges = 3
+node_id = "go_free"
+editor_position = Vector2(1000, 50)
+
+[sub_resource type="Resource" id="node_after_free"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "JUMP_TO_FREE y RETURN_TO_GRAPH funcionaron. Volviste del modo libre correctamente (por keyword o max_exchanges)."
+emotion = "happy"
+node_id = "after_free"
+editor_position = Vector2(1300, 50)
+
+[sub_resource type="Resource" id="node_return_info"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "RETURN_TO_GRAPH se ejecuta automaticamente al salir del modo libre (JUMP_TO_FREE). Usa keywords como 'salir' o alcanza max_exchanges para probarlo."
+emotion = "neutral"
+node_id = "return_info"
+editor_position = Vector2(1000, 200)
+
+[sub_resource type="Resource" id="node_end"]
+script = ExtResource("3_end")
+node_id = "end"
+editor_position = Vector2(1600, 200)
+output_count = 0
+
+[resource]
+script = ExtResource("1_graph")
+graph_id = "test_jump_target"
+display_name = "Test 02: Jump Target + Free Mode"
+description = "Grafo destino para JUMP. Prueba JUMP_TO_FREE (el RETURN_TO_GRAPH se ejecuta implicitamente al salir del modo libre)."
+nodes = {
+"after_free": SubResource("node_after_free"),
+"arrived": SubResource("node_arrived"),
+"end": SubResource("node_end"),
+"go_free": SubResource("node_free"),
+"mode_choice": SubResource("node_choice"),
+"return_info": SubResource("node_return_info"),
+"start": SubResource("node_start")
+}
+connections = Array[Dictionary]([{
+"from_node": "start",
+"from_slot": 0,
+"to_node": "arrived",
+"to_slot": 0
+}, {
+"from_node": "arrived",
+"from_slot": 0,
+"to_node": "mode_choice",
+"to_slot": 0
+}, {
+"from_node": "mode_choice",
+"from_slot": 0,
+"to_node": "go_free",
+"to_slot": 0
+}, {
+"from_node": "mode_choice",
+"from_slot": 1,
+"to_node": "return_info",
+"to_slot": 0
+}, {
+"from_node": "mode_choice",
+"from_slot": 2,
+"to_node": "end",
+"to_slot": 0
+}, {
+"from_node": "go_free",
+"from_slot": 0,
+"to_node": "after_free",
+"to_slot": 0
+}, {
+"from_node": "after_free",
+"from_slot": 0,
+"to_node": "end",
+"to_slot": 0
+}, {
+"from_node": "return_info",
+"from_slot": 0,
+"to_node": "end",
+"to_slot": 0
+}])
+start_node_id = "start"

--- a/examples/resources/tests/test_03_jump_and_ai.tres
+++ b/examples/resources/tests/test_03_jump_and_ai.tres
@@ -1,0 +1,109 @@
+[gd_resource type="Resource" script_class="DialogueGraph" load_steps=15 format=3 uid="uid://wb1ro840h4br"]
+
+[ext_resource type="Script" uid="uid://bltsjidn3ba3t" path="res://addons/ohmydialog/resources/dialogue_graph.gd" id="1_graph"]
+[ext_resource type="Script" uid="uid://reckn0fl8oqw" path="res://addons/ohmydialog/resources/nodes/start_node_data.gd" id="2_start"]
+[ext_resource type="Script" uid="uid://csx5x0eq6vwvk" path="res://addons/ohmydialog/resources/nodes/end_node_data.gd" id="3_end"]
+[ext_resource type="Script" uid="uid://crtfmbxjvqyo2" path="res://addons/ohmydialog/resources/nodes/static_response_node_data.gd" id="4_static"]
+[ext_resource type="Script" uid="uid://cqyrip3w786hr" path="res://addons/ohmydialog/resources/nodes/player_choice_node_data.gd" id="5_choice"]
+[ext_resource type="Script" uid="uid://bwu44xjwalhb1" path="res://addons/ohmydialog/resources/nodes/ai_response_node_data.gd" id="6_ai"]
+[ext_resource type="Script" uid="uid://o4cv1xthgph0" path="res://addons/ohmydialog/resources/nodes/jump_node_data.gd" id="7_jump"]
+
+[sub_resource type="Resource" id="node_start"]
+script = ExtResource("2_start")
+node_id = "start"
+editor_position = Vector2(0, 200)
+
+[sub_resource type="Resource" id="node_intro"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "Test 03: Prueba de JUMP y AI_RESPONSE. Elige una opcion."
+emotion = "neutral"
+node_id = "intro"
+editor_position = Vector2(300, 200)
+
+[sub_resource type="Resource" id="node_choice"]
+script = ExtResource("5_choice")
+choices = PackedStringArray("Probar AI_RESPONSE", "Saltar a otro grafo (JUMP)", "Terminar")
+node_id = "main_choice"
+editor_position = Vector2(600, 200)
+output_count = 3
+
+[sub_resource type="Resource" id="node_ai"]
+script = ExtResource("6_ai")
+prompt_template = "Eres un asistente de pruebas. Responde brevemente confirmando que el nodo AI_RESPONSE funciona correctamente. Se amable y conciso."
+emotion_hint = "friendly"
+max_tokens = 50
+node_id = "ai_test"
+editor_position = Vector2(950, 50)
+
+[sub_resource type="Resource" id="node_ai_done"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "AI_RESPONSE completado exitosamente. La generacion de texto funciona."
+emotion = "happy"
+node_id = "ai_done"
+editor_position = Vector2(1250, 50)
+
+[sub_resource type="Resource" id="node_jump"]
+script = ExtResource("7_jump")
+node_id = "jump_to_graph2"
+editor_position = Vector2(950, 200)
+output_count = 0
+
+[sub_resource type="Resource" id="node_end"]
+script = ExtResource("3_end")
+node_id = "end"
+editor_position = Vector2(1550, 200)
+output_count = 0
+
+[resource]
+script = ExtResource("1_graph")
+graph_id = "test_jump_and_ai"
+display_name = "Test 03: Jump y AI Response"
+description = "Prueba JUMP (salto a otro grafo) y AI_RESPONSE (generacion con LLM)"
+nodes = {
+"ai_done": SubResource("node_ai_done"),
+"ai_test": SubResource("node_ai"),
+"end": SubResource("node_end"),
+"intro": SubResource("node_intro"),
+"jump_to_graph2": SubResource("node_jump"),
+"main_choice": SubResource("node_choice"),
+"start": SubResource("node_start")
+}
+connections = Array[Dictionary]([{
+"from_node": "start",
+"from_slot": 0,
+"to_node": "intro",
+"to_slot": 0
+}, {
+"from_node": "intro",
+"from_slot": 0,
+"to_node": "main_choice",
+"to_slot": 0
+}, {
+"from_node": "main_choice",
+"from_slot": 0,
+"to_node": "ai_test",
+"to_slot": 0
+}, {
+"from_node": "main_choice",
+"from_slot": 1,
+"to_node": "jump_to_graph2",
+"to_slot": 0
+}, {
+"from_node": "main_choice",
+"from_slot": 2,
+"to_node": "end",
+"to_slot": 0
+}, {
+"from_node": "ai_test",
+"from_slot": 0,
+"to_node": "ai_done",
+"to_slot": 0
+}, {
+"from_node": "ai_done",
+"from_slot": 0,
+"to_node": "end",
+"to_slot": 0
+}])
+start_node_id = "start"


### PR DESCRIPTION
## Summary
- Expone variables `test_character`, `test_world`, `test_dialogue` en DialogueTestScene para configurar pruebas desde el Inspector
- Oculta el nodo RETURN_TO_GRAPH de los menús del editor (es interno, usado por JUMP_TO_FREE)
- Añade 3 grafos de test que cubren todos los tipos de nodos

## Test plan
- [ ] Verificar que RETURN_TO_GRAPH no aparece en menú "Add Node"
- [x] Verificar que las variables exportadas aparecen en el Inspector de DialogueTestScene
- [x] Cargar cada grafo de test y ejecutarlo sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)