### PR TITLE
fix(editor): resolver discrepancia node.name vs node_id

### DIFF
--- a/addons/ohmydialog/editor/dialogue_graph_editor.gd
+++ b/addons/ohmydialog/editor/dialogue_graph_editor.gd
@@ -337,15 +337,19 @@ func _rebuild_connections() -> void:
 		return
 
 	for conn in current_graph.connections:
-		var from_node: String = conn.from_node
-		var to_node: String = conn.to_node
+		var from_id: String = conn.from_node
+		var to_id: String = conn.to_node
 
 		# Verify both nodes exist visually
-		if _visual_nodes.has(from_node) and _visual_nodes.has(to_node):
+		if _visual_nodes.has(from_id) and _visual_nodes.has(to_id):
+			# Use the actual GraphNode name (may differ from node_id due to Godot naming)
+			var from_name: StringName = _visual_nodes[from_id].name
+			var to_name: StringName = _visual_nodes[to_id].name
+
 			graph_edit.connect_node(
-				from_node,
+				from_name,
 				conn.from_slot,
-				to_node,
+				to_name,
 				conn.to_slot
 			)
 
@@ -415,10 +419,11 @@ func _remove_node(node_id: String) -> void:
 	# Remove visual node
 	if _visual_nodes.has(node_id):
 		var visual_node: BaseDialogueNode = _visual_nodes[node_id]
+		var visual_name: StringName = visual_node.name
 
-		# Remove connections involving this node
+		# Remove connections involving this node (compare by GraphEdit name)
 		for conn in graph_edit.get_connection_list():
-			if conn.from_node == node_id or conn.to_node == node_id:
+			if conn.from_node == visual_name or conn.to_node == visual_name:
 				graph_edit.disconnect_node(
 					conn.from_node,
 					conn.from_port,
@@ -446,9 +451,17 @@ func _on_connection_request(from_node: StringName, from_port: int, to_node: Stri
 	if not current_graph:
 		return
 
-	# Try to create connection in data
-	if current_graph.connect_nodes(String(from_node), from_port, String(to_node), to_port):
-		# Visual connection
+	# Get actual node_id from visual nodes (GraphEdit may send incorrect names)
+	var from_id := _get_node_id_from_visual(from_node)
+	var to_id := _get_node_id_from_visual(to_node)
+
+	if from_id.is_empty() or to_id.is_empty():
+		push_error("DialogueGraphEditor: Could not resolve node IDs for connection")
+		return
+
+	# Create connection in data using real node_id
+	if current_graph.connect_nodes(from_id, from_port, to_id, to_port):
+		# Visual connection uses GraphEdit's node names
 		graph_edit.connect_node(from_node, from_port, to_node, to_port)
 		graph_modified.emit()
 
@@ -457,12 +470,26 @@ func _on_disconnection_request(from_node: StringName, from_port: int, to_node: S
 	if not current_graph:
 		return
 
+	# Get actual node_id from visual nodes
+	var from_id := _get_node_id_from_visual(from_node)
+	var to_id := _get_node_id_from_visual(to_node)
+
 	# Remove from data
-	current_graph.disconnect_nodes(String(from_node), from_port, String(to_node), to_port)
+	current_graph.disconnect_nodes(from_id, from_port, to_id, to_port)
 
 	# Remove visual connection
 	graph_edit.disconnect_node(from_node, from_port, to_node, to_port)
 	graph_modified.emit()
+
+
+## Resolves the actual node_id from a GraphEdit node name.
+## GraphEdit may report incorrect names (e.g., @GraphNode@XXXXX) when the
+## visual node's name property doesn't match its node_data.node_id.
+func _get_node_id_from_visual(node_name: StringName) -> String:
+	var visual_node := graph_edit.get_node_or_null(NodePath(node_name))
+	if visual_node is BaseDialogueNode:
+		return visual_node.node_data.node_id
+	return String(node_name)
 
 
 func _on_node_selected(node: Node) -> void:

--- a/addons/ohmydialog/editor/nodes/base_dialogue_node.gd
+++ b/addons/ohmydialog/editor/nodes/base_dialogue_node.gd
@@ -41,6 +41,12 @@ var _content_container: VBoxContainer
 func setup(data: DialogueNodeData, graph: DialogueGraph = null) -> void:
 	node_data = data
 	dialogue_graph = graph
+
+	# Ensure node_id is never empty (prevents GraphEdit naming issues)
+	if data.node_id.is_empty():
+		push_error("BaseDialogueNode: node_id is empty, generating fallback UUID")
+		data.node_id = data._generate_uuid()
+
 	name = data.node_id
 	position_offset = data.editor_position
 

--- a/examples/resources/merchant_dialogue.tres
+++ b/examples/resources/merchant_dialogue.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="DialogueGraph" load_steps=38 format=3 uid="uid://i1sbtg72xp43"]
+[gd_resource type="Resource" script_class="DialogueGraph" load_steps=39 format=3 uid="uid://i1sbtg72xp43"]
 
 [ext_resource type="Resource" uid="uid://cmq5w2y3jwple" path="res://examples/resources/merchant_character.tres" id="1_p5lqr"]
 [ext_resource type="Resource" uid="uid://by2uvbmxtdacg" path="res://presets/qwen3_1.7b_gguf_q5_k_m_preset.tres" id="1_v4s23"]
@@ -215,6 +215,13 @@ emotion = "happy"
 node_id = "welcome_static"
 editor_position = Vector2(-100, 200)
 
+[sub_resource type="Resource" id="Resource_v4s23"]
+script = ExtResource("12_setvar")
+value = null
+scope = 1
+node_id = "2dcded74-09db-4345-86dc-0a21a15ff75a"
+editor_position = Vector2(125.80538, -58.689114)
+
 [resource]
 script = ExtResource("2_euopo")
 graph_id = "merchant_demo_complex"
@@ -230,6 +237,7 @@ local_variables = {
 "talked_to_merchant": false
 }
 nodes = {
+"2dcded74-09db-4345-86dc-0a21a15ff75a": SubResource("Resource_v4s23"),
 "after_sample_ai_response": SubResource("node_after_sample_ai"),
 "bow_ai_response": SubResource("node_bow_ai"),
 "bow_purchase_event": SubResource("node_bow_event"),

--- a/examples/resources/tests/test_01_basic_flow.tres
+++ b/examples/resources/tests/test_01_basic_flow.tres
@@ -12,18 +12,41 @@
 [ext_resource type="Script" uid="uid://o4cv1xthgph0" path="res://addons/ohmydialog/resources/nodes/jump_node_data.gd" id="9_oldl7"]
 [ext_resource type="Resource" path="res://examples/resources/fantasy_world.tres" id="11_7qtcy"]
 
-[sub_resource type="Resource" id="node_start"]
-script = ExtResource("2_start")
-node_id = "start"
-editor_position = Vector2(0, 200)
+[sub_resource type="Resource" id="node_condition"]
+script = ExtResource("6_condition")
+variable = "test_value"
+operator = 3
+value = 50
+node_id = "check_value"
+editor_position = Vector2(1150, 125)
+output_count = 2
 
-[sub_resource type="Resource" id="node_welcome"]
-script = ExtResource("4_static")
-speaker = "Sistema"
-text = "Bienvenido al test de flujo basico. Elige una opcion."
-emotion = "neutral"
-node_id = "welcome"
-editor_position = Vector2(250, 200)
+[sub_resource type="Resource" id="node_event_fail"]
+script = ExtResource("8_event")
+event_name = "test_failed"
+event_data = {
+"result": "condition_false",
+"value": 10
+}
+node_id = "event_fail"
+editor_position = Vector2(1450, 200)
+
+[sub_resource type="Resource" id="node_event_pass"]
+script = ExtResource("8_event")
+event_name = "test_passed"
+event_data = {
+"result": "condition_true",
+"value": 100
+}
+node_id = "event_pass"
+editor_position = Vector2(1450, 50)
+
+[sub_resource type="Resource" id="Resource_yksww"]
+script = ExtResource("9_oldl7")
+target_graph_id = "uid://c2vjxlm7hk8qr"
+node_id = "f0916ff3-55bb-4ec6-b8c8-6c714a977704"
+editor_position = Vector2(2080, 400)
+output_count = 0
 
 [sub_resource type="Resource" id="node_choice"]
 script = ExtResource("5_choice")
@@ -31,6 +54,22 @@ choices = PackedStringArray("Probar Condition (true)", "Probar Condition (false)
 node_id = "main_choice"
 editor_position = Vector2(550, 200)
 output_count = 3
+
+[sub_resource type="Resource" id="node_result_fail"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "PASSED: Condition evaluo FALSE correctamente (valor < 50)"
+emotion = "neutral"
+node_id = "result_fail"
+editor_position = Vector2(1750, 200)
+
+[sub_resource type="Resource" id="node_result_pass"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "PASSED: Condition evaluo TRUE correctamente (valor >= 50)"
+emotion = "happy"
+node_id = "result_pass"
+editor_position = Vector2(1740, -20)
 
 [sub_resource type="Resource" id="node_set_high"]
 script = ExtResource("7_setvar")
@@ -46,51 +85,6 @@ value = 10
 node_id = "set_low"
 editor_position = Vector2(850, 200)
 
-[sub_resource type="Resource" id="node_condition"]
-script = ExtResource("6_condition")
-variable = "test_value"
-operator = 3
-value = 50
-node_id = "check_value"
-editor_position = Vector2(1150, 125)
-output_count = 2
-
-[sub_resource type="Resource" id="node_event_pass"]
-script = ExtResource("8_event")
-event_name = "test_passed"
-event_data = {
-"result": "condition_true",
-"value": 100
-}
-node_id = "event_pass"
-editor_position = Vector2(1450, 50)
-
-[sub_resource type="Resource" id="node_event_fail"]
-script = ExtResource("8_event")
-event_name = "test_failed"
-event_data = {
-"result": "condition_false",
-"value": 10
-}
-node_id = "event_fail"
-editor_position = Vector2(1450, 200)
-
-[sub_resource type="Resource" id="node_result_pass"]
-script = ExtResource("4_static")
-speaker = "Sistema"
-text = "PASSED: Condition evaluo TRUE correctamente (valor >= 50)"
-emotion = "happy"
-node_id = "result_pass"
-editor_position = Vector2(1740, -20)
-
-[sub_resource type="Resource" id="node_result_fail"]
-script = ExtResource("4_static")
-speaker = "Sistema"
-text = "PASSED: Condition evaluo FALSE correctamente (valor < 50)"
-emotion = "neutral"
-node_id = "result_fail"
-editor_position = Vector2(1750, 200)
-
 [sub_resource type="Resource" id="node_skip"]
 script = ExtResource("4_static")
 speaker = "Sistema"
@@ -99,12 +93,18 @@ emotion = "neutral"
 node_id = "skip_msg"
 editor_position = Vector2(850, 350)
 
-[sub_resource type="Resource" id="Resource_yksww"]
-script = ExtResource("9_oldl7")
-target_graph_id = "uid://c2vjxlm7hk8qr"
-node_id = "f0916ff3-55bb-4ec6-b8c8-6c714a977704"
-editor_position = Vector2(2080, 400)
-output_count = 0
+[sub_resource type="Resource" id="node_start"]
+script = ExtResource("2_start")
+node_id = "start"
+editor_position = Vector2(0, 200)
+
+[sub_resource type="Resource" id="node_welcome"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "Bienvenido al test de flujo basico. Elige una opcion."
+emotion = "neutral"
+node_id = "welcome"
+editor_position = Vector2(250, 200)
 
 [resource]
 script = ExtResource("1_graph")

--- a/examples/resources/tests/test_02_jump_target.tres
+++ b/examples/resources/tests/test_02_jump_target.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="DialogueGraph" load_steps=13 format=3 uid="uid://c2vjxlm7hk8qr"]
+[gd_resource type="Resource" script_class="DialogueGraph" load_steps=14 format=3 uid="uid://c2vjxlm7hk8qr"]
 
 [ext_resource type="Script" uid="uid://bltsjidn3ba3t" path="res://addons/ohmydialog/resources/dialogue_graph.gd" id="1_graph"]
 [ext_resource type="Script" uid="uid://reckn0fl8oqw" path="res://addons/ohmydialog/resources/nodes/start_node_data.gd" id="2_start"]
@@ -6,34 +6,6 @@
 [ext_resource type="Script" uid="uid://crtfmbxjvqyo2" path="res://addons/ohmydialog/resources/nodes/static_response_node_data.gd" id="4_static"]
 [ext_resource type="Script" uid="uid://cqyrip3w786hr" path="res://addons/ohmydialog/resources/nodes/player_choice_node_data.gd" id="5_choice"]
 [ext_resource type="Script" uid="uid://c4akvhu8851x2" path="res://addons/ohmydialog/resources/nodes/jump_to_free_node_data.gd" id="6_free"]
-
-[sub_resource type="Resource" id="node_start"]
-script = ExtResource("2_start")
-node_id = "start"
-editor_position = Vector2(0, 200)
-
-[sub_resource type="Resource" id="node_arrived"]
-script = ExtResource("4_static")
-speaker = "Sistema"
-text = "Has llegado al GRAFO 2 mediante JUMP. El salto funciono correctamente."
-emotion = "happy"
-node_id = "arrived"
-editor_position = Vector2(300, 200)
-
-[sub_resource type="Resource" id="node_choice"]
-script = ExtResource("5_choice")
-choices = PackedStringArray("Probar JUMP_TO_FREE (modo libre)", "Info sobre RETURN_TO_GRAPH", "Terminar aqui con END")
-node_id = "mode_choice"
-editor_position = Vector2(650, 200)
-output_count = 3
-
-[sub_resource type="Resource" id="node_free"]
-script = ExtResource("6_free")
-context_prompt = "Eres un asistente de pruebas en modo conversacion libre. Responde brevemente. Cuando el usuario diga 'salir', 'volver' o 'exit', despidete."
-return_keywords = PackedStringArray("salir", "volver", "exit")
-max_exchanges = 3
-node_id = "go_free"
-editor_position = Vector2(1000, 50)
 
 [sub_resource type="Resource" id="node_after_free"]
 script = ExtResource("4_static")
@@ -43,6 +15,35 @@ emotion = "happy"
 node_id = "after_free"
 editor_position = Vector2(1300, 50)
 
+[sub_resource type="Resource" id="node_arrived"]
+script = ExtResource("4_static")
+speaker = "Sistema"
+text = "Has llegado al GRAFO 2 mediante JUMP. El salto funciono correctamente."
+emotion = "happy"
+node_id = "arrived"
+editor_position = Vector2(300, 200)
+
+[sub_resource type="Resource" id="node_end"]
+script = ExtResource("3_end")
+node_id = "end"
+editor_position = Vector2(1600, 200)
+output_count = 0
+
+[sub_resource type="Resource" id="node_free"]
+script = ExtResource("6_free")
+context_prompt = "Eres un asistente de pruebas en modo conversacion libre. Responde brevemente. Cuando el usuario diga 'salir', 'volver' o 'exit', despidete."
+return_keywords = PackedStringArray("salir", "volver", "exit")
+max_exchanges = 3
+node_id = "go_free"
+editor_position = Vector2(1000, 50)
+
+[sub_resource type="Resource" id="node_choice"]
+script = ExtResource("5_choice")
+choices = PackedStringArray("Probar JUMP_TO_FREE (modo libre)", "Info sobre RETURN_TO_GRAPH", "Terminar aqui con END")
+node_id = "mode_choice"
+editor_position = Vector2(650, 200)
+output_count = 3
+
 [sub_resource type="Resource" id="node_return_info"]
 script = ExtResource("4_static")
 speaker = "Sistema"
@@ -51,11 +52,10 @@ emotion = "neutral"
 node_id = "return_info"
 editor_position = Vector2(1000, 200)
 
-[sub_resource type="Resource" id="node_end"]
-script = ExtResource("3_end")
-node_id = "end"
-editor_position = Vector2(1600, 200)
-output_count = 0
+[sub_resource type="Resource" id="node_start"]
+script = ExtResource("2_start")
+node_id = "start"
+editor_position = Vector2(0, 200)
 
 [resource]
 script = ExtResource("1_graph")

--- a/examples/resources/tests/test_03_jump_and_ai.tres
+++ b/examples/resources/tests/test_03_jump_and_ai.tres
@@ -8,25 +8,13 @@
 [ext_resource type="Script" uid="uid://bwu44xjwalhb1" path="res://addons/ohmydialog/resources/nodes/ai_response_node_data.gd" id="6_ai"]
 [ext_resource type="Script" uid="uid://o4cv1xthgph0" path="res://addons/ohmydialog/resources/nodes/jump_node_data.gd" id="7_jump"]
 
-[sub_resource type="Resource" id="node_start"]
-script = ExtResource("2_start")
-node_id = "start"
-editor_position = Vector2(0, 200)
-
-[sub_resource type="Resource" id="node_intro"]
+[sub_resource type="Resource" id="node_ai_done"]
 script = ExtResource("4_static")
 speaker = "Sistema"
-text = "Test 03: Prueba de JUMP y AI_RESPONSE. Elige una opcion."
-emotion = "neutral"
-node_id = "intro"
-editor_position = Vector2(300, 200)
-
-[sub_resource type="Resource" id="node_choice"]
-script = ExtResource("5_choice")
-choices = PackedStringArray("Probar AI_RESPONSE", "Saltar a otro grafo (JUMP)", "Terminar")
-node_id = "main_choice"
-editor_position = Vector2(600, 200)
-output_count = 3
+text = "AI_RESPONSE completado exitosamente. La generacion de texto funciona."
+emotion = "happy"
+node_id = "ai_done"
+editor_position = Vector2(1250, 50)
 
 [sub_resource type="Resource" id="node_ai"]
 script = ExtResource("6_ai")
@@ -36,13 +24,19 @@ max_tokens = 50
 node_id = "ai_test"
 editor_position = Vector2(950, 50)
 
-[sub_resource type="Resource" id="node_ai_done"]
+[sub_resource type="Resource" id="node_end"]
+script = ExtResource("3_end")
+node_id = "end"
+editor_position = Vector2(1550, 200)
+output_count = 0
+
+[sub_resource type="Resource" id="node_intro"]
 script = ExtResource("4_static")
 speaker = "Sistema"
-text = "AI_RESPONSE completado exitosamente. La generacion de texto funciona."
-emotion = "happy"
-node_id = "ai_done"
-editor_position = Vector2(1250, 50)
+text = "Test 03: Prueba de JUMP y AI_RESPONSE. Elige una opcion."
+emotion = "neutral"
+node_id = "intro"
+editor_position = Vector2(300, 200)
 
 [sub_resource type="Resource" id="node_jump"]
 script = ExtResource("7_jump")
@@ -50,11 +44,17 @@ node_id = "jump_to_graph2"
 editor_position = Vector2(950, 200)
 output_count = 0
 
-[sub_resource type="Resource" id="node_end"]
-script = ExtResource("3_end")
-node_id = "end"
-editor_position = Vector2(1550, 200)
-output_count = 0
+[sub_resource type="Resource" id="node_choice"]
+script = ExtResource("5_choice")
+choices = PackedStringArray("Probar AI_RESPONSE", "Saltar a otro grafo (JUMP)", "Terminar")
+node_id = "main_choice"
+editor_position = Vector2(600, 200)
+output_count = 3
+
+[sub_resource type="Resource" id="node_start"]
+script = ExtResource("2_start")
+node_id = "start"
+editor_position = Vector2(0, 200)
 
 [resource]
 script = ExtResource("1_graph")

--- a/gdextension/build.bat
+++ b/gdextension/build.bat
@@ -10,8 +10,8 @@ echo ========================================
 
 cd /d "%~dp0"
 
-REM Check if scons is available
-where scons >nul 2>&1
+REM Check if scons is available (use python -m to avoid Device Guard blocks)
+python -m SCons --version >nul 2>&1
 if %ERRORLEVEL% neq 0 (
     echo [ERROR] SCons not found. Install with: pip install scons
     exit /b 1
@@ -188,7 +188,7 @@ set SCONS_ARGS=platform=%PLATFORM% target=%TARGET% llama_backend=%LLAMA_BACKEND%
 set SCONS_ARGS=%SCONS_ARGS% llama_native=%LLAMA_NATIVE% llama_avx2=%LLAMA_AVX2% llama_rebuild=%LLAMA_REBUILD%
 if "%LLAMA_ALL_BACKENDS%"=="yes" set SCONS_ARGS=%SCONS_ARGS% llama_all_backends=yes
 if "%LLAMA_DYNAMIC%"=="yes" set SCONS_ARGS=%SCONS_ARGS% llama_dynamic=yes
-scons %SCONS_ARGS% -j%JOBS%
+python -m SCons %SCONS_ARGS% -j%JOBS%
 
 if %ERRORLEVEL% neq 0 (
     echo.


### PR DESCRIPTION
## Summary
- Fix bug donde GraphEdit renombra nodos a @GraphNode@XXXXX
- Las conexiones ahora resuelven el node_id real desde node_data
- Validación preventiva en setup() para node_id vacío
- Fix build.bat para Windows Device Guard

## Test plan
- [x] Abrir grafo existente y verificar conexiones se muestran
- [x] Crear nuevas conexiones entre nodos
- [x] Eliminar nodos y verificar conexiones se limpian
- [x] Guardar y recargar grafo

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)