### PR TITLE
docs(wiki): sampling parameters reference page

### DIFF
--- a/docs/Guides/character-identity.html
+++ b/docs/Guides/character-identity.html
@@ -287,6 +287,9 @@
             <li><a href="character-identity.html"
                 class="flex items-center gap-2 py-2 px-4 rounded-md text-sm bg-gradient-to-r from-ai-cyan/10 to-transparent text-ai-cyan border-l-2 border-ai-cyan"><span
                   class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html"
                 class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
                   class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>

--- a/docs/Guides/csharp-bindings.html
+++ b/docs/Guides/csharp-bindings.html
@@ -119,6 +119,9 @@
           <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono"><span class="text-gray-600 text-[0.65rem]">//</span> Guides</div>
           <ul>
             <li><a href="character-identity.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>
             <li><a href="csharp-bindings.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm bg-gradient-to-r from-ai-cyan/10 to-transparent text-ai-cyan border-l-2 border-ai-cyan"><span class="opacity-70">&#x1F537;</span> C# Bindings</a></li>
           </ul>

--- a/docs/Guides/example-basic-npc.html
+++ b/docs/Guides/example-basic-npc.html
@@ -116,6 +116,9 @@
           <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono"><span class="text-gray-600 text-[0.65rem]">//</span> Guides</div>
           <ul>
             <li><a href="character-identity.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>
             <li><a href="csharp-bindings.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F537;</span> C# Bindings</a></li>
           </ul>

--- a/docs/Guides/example-branching.html
+++ b/docs/Guides/example-branching.html
@@ -116,6 +116,9 @@
           <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono"><span class="text-gray-600 text-[0.65rem]">//</span> Guides</div>
           <ul>
             <li><a href="character-identity.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>
             <li><a href="csharp-bindings.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F537;</span> C# Bindings</a></li>
           </ul>

--- a/docs/Guides/example-merchant.html
+++ b/docs/Guides/example-merchant.html
@@ -193,6 +193,9 @@
           <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono"><span class="text-gray-600 text-[0.65rem]">//</span> Guides</div>
           <ul>
             <li><a href="character-identity.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>
             <li><a href="csharp-bindings.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F537;</span> C# Bindings</a></li>
           </ul>

--- a/docs/Guides/first-npc.html
+++ b/docs/Guides/first-npc.html
@@ -241,6 +241,9 @@
           <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono"><span class="text-gray-600 text-[0.65rem]">//</span> Guides</div>
           <ul>
             <li><a href="character-identity.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>
             <li><a href="csharp-bindings.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F4BB;</span> C# Bindings</a></li>
           </ul>

--- a/docs/Guides/index.html
+++ b/docs/Guides/index.html
@@ -225,6 +225,9 @@
           <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono"><span class="text-gray-600 text-[0.65rem]">//</span> Guides</div>
           <ul>
             <li><a href="character-identity.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>
             <li><a href="csharp-bindings.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F537;</span> C# Bindings</a></li>
           </ul>

--- a/docs/Guides/installation.html
+++ b/docs/Guides/installation.html
@@ -271,6 +271,9 @@
             <li><a href="character-identity.html"
                 class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
                   class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html"
                 class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
                   class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>

--- a/docs/Guides/quickstart.html
+++ b/docs/Guides/quickstart.html
@@ -271,6 +271,9 @@
             <li><a href="character-identity.html"
                 class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
                   class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html"
                 class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
                   class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>

--- a/docs/Guides/sampling-parameters.html
+++ b/docs/Guides/sampling-parameters.html
@@ -1,0 +1,604 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sampling Parameters - OhMyDialogSystem Wiki</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="../tailwind.config.js"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../base.css">
+
+  <script>
+    const I18n = {
+      lang: new URLSearchParams(window.location.search).get('lang') || localStorage.getItem('wiki-lang') || (navigator.language.startsWith('es') ? 'es' : 'en'),
+      t: {
+        es: {
+          navInstallation: 'Instalacion', navFirstNpc: 'Tu Primer NPC', navArchitecture: 'Arquitectura',
+          navCiCd: 'CI/CD y Releases', navVisualEditor: 'Editor Visual', navLocalization: 'Localizacion',
+          pageTitle: 'Parametros de Sampling',
+          pageDesc: 'Referencia completa de los parametros de generacion del AIPreset: que hace cada uno, su rango valido y como combinarlos.',
+          hWhere: 'Donde se configuran',
+          whereDesc: 'Estos parametros viven en el recurso AIPreset (resources/ai_preset.gd). Se editan en el Inspector de Godot, se aplican al modelo via apply_to(), o se pasan a la generacion desde codigo. El AIPreset se puede asociar a un ModelConfig como sampling por defecto.',
+          tipPreset: 'Si no quieres ajustar a mano, usa los 5 presets built-in (mas abajo) o el boton "Generate AI Preset" del Model Manager.',
+          hTempSampling: 'Temperature y Sampling',
+          tempSamplingDesc: 'Controlan cuanta aleatoriedad y diversidad tiene la seleccion de tokens.',
+          hOutput: 'Salida',
+          outputDesc: 'Limitan la longitud y el corte de la respuesta.',
+          hRepetition: 'Repeticion',
+          repetitionDesc: 'Penalizan que el modelo repita texto. Subir demasiado degrada la coherencia.',
+          hContext: 'Contexto',
+          contextDesc: 'Definen el tamaño de ventana del modelo y cuanto se reserva para la respuesta.',
+          hAdvanced: 'Avanzado',
+          advancedDesc: 'Reproducibilidad y muestreo Mirostat. Mirostat reemplaza a top_k/top_p cuando esta activo.',
+          thParam: 'Parametro', thRange: 'Rango', thDefault: 'Default', thDesc: 'Descripcion',
+          dTemperature: 'Aleatoriedad de la generacion. Mas alto = mas creativo; mas bajo = mas determinista.',
+          dTopP: 'Nucleus sampling: solo considera tokens cuya probabilidad acumulada llegue a top_p.',
+          dTopK: 'Solo considera los K tokens mas probables.',
+          dMinP: 'Probabilidad minima para que un token sea considerado (Min-P sampling).',
+          dTypicalP: 'Typical sampling. Mas bajo = texto mas predecible. 1.0 = deshabilitado.',
+          dMaxTokens: 'Maximo de tokens a generar por respuesta.',
+          dStop: 'Secuencias que detienen la generacion al aparecer.',
+          dRepeatPenalty: 'Penalizacion por repetir tokens. Mas alto = menos repeticion.',
+          dRepeatLastN: 'Cuantos tokens recientes considerar para la penalizacion de repeticion.',
+          dFreqPenalty: 'Penalizacion por frecuencia (estilo OpenAI). Penaliza segun cuantas veces aparecio el token.',
+          dPresPenalty: 'Penalizacion por presencia (estilo OpenAI). Penaliza si el token aparecio aunque sea una vez.',
+          dContextSize: 'Tamaño maximo de contexto en tokens (depende del modelo).',
+          dResponseReserve: 'Tokens reservados para la respuesta dentro de la ventana de contexto.',
+          dSeed: 'Semilla del generador aleatorio. -1 = semilla aleatoria (no reproducible).',
+          dMirostat: 'Modo Mirostat (0 = desactivado, 1 = v1, 2 = v2). Controla la perplejidad objetivo.',
+          dMirostatTau: 'Entropia objetivo (tau) de Mirostat. Solo se usa si mirostat > 0.',
+          dMirostatEta: 'Tasa de aprendizaje (eta) de Mirostat. Solo se usa si mirostat > 0.',
+          hPresets: 'Presets Built-in',
+          presetsDesc: 'Cinco configuraciones listas para usar (factory methods en AIPreset). Valores reales:',
+          thPreset: 'Preset', thUseCase: 'Caso de uso',
+          ucCreative: 'Narrativa, brainstorming, respuestas imaginativas.',
+          ucBalanced: 'Default para la mayoria de los dialogos.',
+          ucConsistent: 'Tutoriales y escenas guionizadas, salida predecible.',
+          ucRoleplay: 'Dialogo en personaje con buena expresion de personalidad.',
+          ucTechnical: 'Enciclopedias o guias in-game: respuestas precisas y factuales.',
+          hTips: 'Tips practicos',
+          tip1: 'Ajusta primero temperature; es la palanca de mayor impacto.',
+          tip2: 'temperature alto + top_p alto = caotico. Sube uno y baja el otro.',
+          tip3: 'Si el NPC se repite, sube repeat_penalty a 1.1-1.15 antes de tocar otra cosa.',
+          tip4: 'Fija seed (>= 0) para reproducir bugs o tests deterministas.',
+          tip5: 'Mirostat ignora top_k/top_p: no esperes que esos parametros hagan efecto con mirostat > 0.',
+          hRelated: 'Relacionado',
+          relResources: 'Referencia del recurso AIPreset y ModelConfig.',
+          relFirstNpc: 'Aplica un preset a tu primer NPC.',
+          backToGuides: 'Volver a Guides',
+        },
+        en: {
+          navInstallation: 'Installation', navFirstNpc: 'Your First NPC', navArchitecture: 'Architecture',
+          navCiCd: 'CI/CD & Releases', navVisualEditor: 'Visual Editor', navLocalization: 'Localization',
+          pageTitle: 'Sampling Parameters',
+          pageDesc: 'Complete reference of AIPreset generation parameters: what each one does, its valid range, and how to combine them.',
+          hWhere: 'Where they are configured',
+          whereDesc: 'These parameters live in the AIPreset resource (resources/ai_preset.gd). Edit them in the Godot Inspector, apply them to the model via apply_to(), or pass them to generation from code. An AIPreset can be attached to a ModelConfig as its default sampling.',
+          tipPreset: 'If you would rather not tune by hand, use the 5 built-in presets (below) or the "Generate AI Preset" button in the Model Manager.',
+          hTempSampling: 'Temperature & Sampling',
+          tempSamplingDesc: 'Control how much randomness and diversity the token selection has.',
+          hOutput: 'Output',
+          outputDesc: 'Limit response length and where it stops.',
+          hRepetition: 'Repetition',
+          repetitionDesc: 'Penalize the model for repeating text. Pushing these too high degrades coherence.',
+          hContext: 'Context',
+          contextDesc: 'Define the model window size and how much is reserved for the response.',
+          hAdvanced: 'Advanced',
+          advancedDesc: 'Reproducibility and Mirostat sampling. Mirostat replaces top_k/top_p when active.',
+          thParam: 'Parameter', thRange: 'Range', thDefault: 'Default', thDesc: 'Description',
+          dTemperature: 'Generation randomness. Higher = more creative; lower = more deterministic.',
+          dTopP: 'Nucleus sampling: only consider tokens whose cumulative probability reaches top_p.',
+          dTopK: 'Only consider the top K most likely tokens.',
+          dMinP: 'Minimum probability for a token to be considered (Min-P sampling).',
+          dTypicalP: 'Typical sampling. Lower = more predictable text. 1.0 = disabled.',
+          dMaxTokens: 'Maximum tokens to generate per response.',
+          dStop: 'Sequences that stop generation when encountered.',
+          dRepeatPenalty: 'Penalty for repeating tokens. Higher = less repetition.',
+          dRepeatLastN: 'How many recent tokens to consider for the repetition penalty.',
+          dFreqPenalty: 'Frequency penalty (OpenAI-style). Penalizes based on how often the token appeared.',
+          dPresPenalty: 'Presence penalty (OpenAI-style). Penalizes if the token appeared at all.',
+          dContextSize: 'Maximum context size in tokens (model-dependent).',
+          dResponseReserve: 'Tokens reserved for the response inside the context window.',
+          dSeed: 'Random generator seed. -1 = random seed (not reproducible).',
+          dMirostat: 'Mirostat mode (0 = disabled, 1 = v1, 2 = v2). Controls target perplexity.',
+          dMirostatTau: 'Mirostat target entropy (tau). Only used if mirostat > 0.',
+          dMirostatEta: 'Mirostat learning rate (eta). Only used if mirostat > 0.',
+          hPresets: 'Built-in Presets',
+          presetsDesc: 'Five ready-to-use configurations (factory methods on AIPreset). Real values:',
+          thPreset: 'Preset', thUseCase: 'Use case',
+          ucCreative: 'Storytelling, brainstorming, imaginative responses.',
+          ucBalanced: 'Default for most dialogue.',
+          ucConsistent: 'Tutorials and scripted scenes, predictable output.',
+          ucRoleplay: 'In-character dialogue with good personality expression.',
+          ucTechnical: 'In-game encyclopedias or guides: precise, factual answers.',
+          hTips: 'Practical tips',
+          tip1: 'Tune temperature first; it is the highest-impact lever.',
+          tip2: 'High temperature + high top_p = chaotic. Raise one, lower the other.',
+          tip3: 'If the NPC repeats itself, raise repeat_penalty to 1.1-1.15 before touching anything else.',
+          tip4: 'Set seed (>= 0) to reproduce bugs or run deterministic tests.',
+          tip5: 'Mirostat ignores top_k/top_p: do not expect those to take effect when mirostat > 0.',
+          hRelated: 'Related',
+          relResources: 'AIPreset and ModelConfig resource reference.',
+          relFirstNpc: 'Apply a preset to your first NPC.',
+          backToGuides: 'Back to Guides',
+        }
+      },
+      init() {
+        localStorage.setItem('wiki-lang', this.lang);
+        document.documentElement.lang = this.lang;
+        document.querySelectorAll('[data-i18n]').forEach(el => {
+          const key = el.dataset.i18n;
+          if (this.t[this.lang][key]) el.textContent = this.t[this.lang][key];
+        });
+        document.querySelectorAll('[data-lang-switch]').forEach(btn => {
+          const isActive = btn.dataset.langSwitch === this.lang;
+          btn.classList.toggle('bg-ai-cyan/20', isActive);
+          btn.classList.toggle('text-ai-cyan', isActive);
+          btn.classList.toggle('border-ai-cyan', isActive);
+          btn.classList.toggle('text-gray-500', !isActive);
+          btn.classList.toggle('border-transparent', !isActive);
+        });
+      },
+      switch(lang) {
+        this.lang = lang;
+        localStorage.setItem('wiki-lang', lang);
+        const url = new URL(window.location);
+        url.searchParams.set('lang', lang);
+        history.replaceState({}, '', url);
+        this.init();
+      }
+    };
+    document.addEventListener('DOMContentLoaded', () => I18n.init());
+  </script>
+
+  <style>
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background-color: #0a0d12;
+      color: #e6edf3;
+      line-height: 1.7;
+    }
+
+    .text-gradient-ai {
+      background: linear-gradient(135deg, #00d4ff 0%, #a855f7 50%, #ec4899 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    table.param-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+
+    table.param-table th,
+    table.param-table td {
+      text-align: left;
+      padding: 0.6rem 0.8rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+      vertical-align: top;
+    }
+
+    table.param-table th {
+      color: #a855f7;
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+    }
+
+    table.param-table code {
+      font-family: 'JetBrains Mono', monospace;
+      color: #00d4ff;
+      font-size: 0.85rem;
+    }
+
+    table.param-table td.mono {
+      font-family: 'JetBrains Mono', monospace;
+      color: #e6edf3;
+      white-space: nowrap;
+    }
+  </style>
+</head>
+
+<body class="min-h-screen">
+  <canvas id="neural-bg"></canvas>
+  <div class="flex min-h-screen relative z-10">
+    <!-- Sidebar -->
+    <nav
+      class="w-72 fixed top-0 left-0 h-screen overflow-y-auto bg-gradient-to-b from-bg-secondary to-bg-primary border-r border-border-default z-50 shadow-[4px_0_20px_rgba(0,0,0,0.5)]">
+      <div
+        class="absolute top-0 right-0 w-px h-full bg-gradient-to-b from-transparent via-ai-cyan to-transparent opacity-30">
+      </div>
+      <div class="p-6 text-center border-b border-border-default">
+        <div class="w-16 h-16 mx-auto mb-4"><img src="../logo-eldritch.png" alt="OhMyDialogSystem"
+            class="w-full h-full drop-shadow-[0_0_10px_rgba(0,212,255,0.4)]"></div>
+        <div class="text-lg font-bold uppercase tracking-wider text-gradient-ai">OhMyDialogSystem</div>
+        <div class="text-xs text-gray-500 uppercase tracking-widest mt-1">AI-Powered Dialogues</div>
+      </div>
+      <div class="px-6 py-3 border-b border-border-default flex gap-2">
+        <button data-lang-switch="es" onclick="I18n.switch('es')"
+          class="flex-1 py-1.5 text-center text-xs font-medium rounded border transition-colors hover:bg-ai-cyan/10">ES</button>
+        <button data-lang-switch="en" onclick="I18n.switch('en')"
+          class="flex-1 py-1.5 text-center text-xs font-medium rounded border transition-colors hover:bg-ai-cyan/10">EN</button>
+      </div>
+      <div class="p-4">
+        <div class="mb-6">
+          <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono">
+            <span class="text-gray-600 text-[0.65rem]">//</span> General
+          </div>
+          <ul>
+            <li><a href="../home.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F3E0;</span> Home</a></li>
+          </ul>
+        </div>
+        <div class="mb-6">
+          <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono">
+            <span class="text-gray-600 text-[0.65rem]">//</span> Getting Started
+          </div>
+          <ul>
+            <li><a href="installation.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F4E6;</span> <span data-i18n="navInstallation">Instalacion</span></a></li>
+            <li><a href="quickstart.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F680;</span> Quick Start</a></li>
+            <li><a href="first-npc.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F3AE;</span> <span data-i18n="navFirstNpc">Tu Primer NPC</span></a></li>
+            <li><a href="visual-editor.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F3A8;</span> <span data-i18n="navVisualEditor">Editor Visual</span></a></li>
+          </ul>
+        </div>
+        <div class="mb-6">
+          <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono">
+            <span class="text-gray-600 text-[0.65rem]">//</span> API Reference
+          </div>
+          <ul>
+            <li><a href="../API/index.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F4DA;</span> Overview</a></li>
+            <li><a href="../API/llama-interface.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F999;</span> LlamaInterface</a></li>
+            <li><a href="../API/dialogue-manager.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F4AC;</span> DialogueManager</a></li>
+            <li><a href="../API/memory-manager.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F9E0;</span> MemoryManager</a></li>
+            <li><a href="../API/tts-manager.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F50A;</span> TTSManager</a></li>
+            <li><a href="../API/resources.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F4C4;</span> Resources</a></li>
+          </ul>
+        </div>
+        <div class="mb-6">
+          <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono">
+            <span class="text-gray-600 text-[0.65rem]">//</span> Technical
+          </div>
+          <ul>
+            <li><a href="../Technical/index.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x2699;&#xFE0F;</span> Overview</a></li>
+            <li><a href="../Technical/architecture.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F3D7;&#xFE0F;</span> <span
+                  data-i18n="navArchitecture">Arquitectura</span></a></li>
+            <li><a href="../Technical/dialogue-nodes.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F537;</span> Dialogue Nodes</a></li>
+            <li><a href="../Technical/memory-system.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F9E0;</span> Memory System</a></li>
+            <li><a href="../Technical/localization.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F310;</span> <span data-i18n="navLocalization">Localizacion</span></a></li>
+            <li><a href="../Technical/gdextension.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F527;</span> GDExtension Build</a></li>
+            <li><a href="../Technical/ci-cd-release.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F680;</span> <span data-i18n="navCiCd">CI/CD y Releases</span></a></li>
+          </ul>
+        </div>
+        <div class="mb-6">
+          <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono">
+            <span class="text-gray-600 text-[0.65rem]">//</span> Guides
+          </div>
+          <ul>
+            <li><a href="character-identity.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm bg-gradient-to-r from-ai-cyan/10 to-transparent text-ai-cyan border-l-2 border-ai-cyan"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
+            <li><a href="tts-setup.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>
+            <li><a href="csharp-bindings.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F4BB;</span> C# Bindings</a></li>
+          </ul>
+        </div>
+        <div class="mb-6">
+          <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono">
+            <span class="text-gray-600 text-[0.65rem]">//</span> External
+          </div>
+          <ul>
+            <li><a href="https://github.com/lobinuxsoft/OhMyDialogSystem" target="_blank"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F517;</span> GitHub</a></li>
+            <li><a href="https://github.com/users/lobinuxsoft/projects/5" target="_blank"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F4CB;</span> Project Board</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="flex-1 ml-72 p-12 max-w-5xl">
+      <!-- Breadcrumb -->
+      <div class="text-sm text-gray-500 mb-8 pb-4 border-b border-border-default font-mono">
+        <a href="../home.html" class="text-gray-400 hover:text-ai-cyan">Wiki</a>
+        <span class="mx-2 text-ai-purple">/</span>
+        <a href="index.html" class="text-gray-400 hover:text-ai-cyan">Guides</a>
+        <span class="mx-2 text-ai-purple">/</span>
+        <span>Sampling Parameters</span>
+      </div>
+
+      <!-- Page Title -->
+      <h1 class="text-4xl font-bold mb-4 pb-4 border-b border-border-default relative">
+        <span class="text-gradient-ai" data-i18n="pageTitle">Parametros de Sampling</span>
+        <span
+          class="absolute bottom-0 left-0 w-24 h-0.5 bg-gradient-to-r from-ai-cyan to-ai-purple shadow-glow-cyan"></span>
+      </h1>
+
+      <!-- Description -->
+      <p class="text-gray-400 mb-8 text-lg" data-i18n="pageDesc">
+        Referencia completa de los parametros de generacion del AIPreset.
+      </p>
+
+      <!-- Where -->
+      <section class="mb-10">
+        <h2 class="text-2xl font-bold text-ai-cyan mb-4 flex items-center gap-2">
+          <span>&#x1F4CD;</span><span data-i18n="hWhere">Donde se configuran</span>
+        </h2>
+        <p class="text-gray-300 mb-4" data-i18n="whereDesc">Estos parametros viven en el recurso AIPreset.</p>
+        <div class="relative p-5 rounded-xl border border-ai-cyan/30 bg-gradient-to-br from-ai-cyan/5 to-transparent">
+          <div class="flex items-start gap-4">
+            <div class="text-2xl">&#x1F4A1;</div>
+            <p class="text-gray-300 text-sm" data-i18n="tipPreset">Usa los 5 presets built-in o "Generate AI Preset".</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Temperature & Sampling -->
+      <section class="mb-10">
+        <h2 class="text-2xl font-bold text-ai-purple mb-2 flex items-center gap-2">
+          <span>&#x1F321;&#xFE0F;</span><span data-i18n="hTempSampling">Temperature y Sampling</span>
+        </h2>
+        <p class="text-gray-400 text-sm mb-4" data-i18n="tempSamplingDesc"></p>
+        <div class="rounded-xl border border-border-default bg-bg-tertiary/30 overflow-x-auto">
+          <table class="param-table">
+            <thead>
+              <tr>
+                <th data-i18n="thParam">Parametro</th>
+                <th data-i18n="thRange">Rango</th>
+                <th data-i18n="thDefault">Default</th>
+                <th data-i18n="thDesc">Descripcion</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td><code>temperature</code></td><td class="mono">0.0 - 2.0</td><td class="mono">0.7</td><td data-i18n="dTemperature"></td></tr>
+              <tr><td><code>top_p</code></td><td class="mono">0.0 - 1.0</td><td class="mono">0.9</td><td data-i18n="dTopP"></td></tr>
+              <tr><td><code>top_k</code></td><td class="mono">0 - 100</td><td class="mono">40</td><td data-i18n="dTopK"></td></tr>
+              <tr><td><code>min_p</code></td><td class="mono">0.0 - 1.0</td><td class="mono">0.05</td><td data-i18n="dMinP"></td></tr>
+              <tr><td><code>typical_p</code></td><td class="mono">0.0 - 1.0</td><td class="mono">1.0</td><td data-i18n="dTypicalP"></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Output -->
+      <section class="mb-10">
+        <h2 class="text-2xl font-bold text-ai-purple mb-2 flex items-center gap-2">
+          <span>&#x1F4E4;</span><span data-i18n="hOutput">Salida</span>
+        </h2>
+        <p class="text-gray-400 text-sm mb-4" data-i18n="outputDesc"></p>
+        <div class="rounded-xl border border-border-default bg-bg-tertiary/30 overflow-x-auto">
+          <table class="param-table">
+            <thead>
+              <tr>
+                <th data-i18n="thParam">Parametro</th>
+                <th data-i18n="thRange">Rango</th>
+                <th data-i18n="thDefault">Default</th>
+                <th data-i18n="thDesc">Descripcion</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td><code>max_tokens</code></td><td class="mono">1 - 4096</td><td class="mono">256</td><td data-i18n="dMaxTokens"></td></tr>
+              <tr><td><code>stop_sequences</code></td><td class="mono">Array[String]</td><td class="mono">[]</td><td data-i18n="dStop"></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Repetition -->
+      <section class="mb-10">
+        <h2 class="text-2xl font-bold text-ai-purple mb-2 flex items-center gap-2">
+          <span>&#x1F501;</span><span data-i18n="hRepetition">Repeticion</span>
+        </h2>
+        <p class="text-gray-400 text-sm mb-4" data-i18n="repetitionDesc"></p>
+        <div class="rounded-xl border border-border-default bg-bg-tertiary/30 overflow-x-auto">
+          <table class="param-table">
+            <thead>
+              <tr>
+                <th data-i18n="thParam">Parametro</th>
+                <th data-i18n="thRange">Rango</th>
+                <th data-i18n="thDefault">Default</th>
+                <th data-i18n="thDesc">Descripcion</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td><code>repeat_penalty</code></td><td class="mono">1.0 - 2.0</td><td class="mono">1.1</td><td data-i18n="dRepeatPenalty"></td></tr>
+              <tr><td><code>repeat_last_n</code></td><td class="mono">0 - 256</td><td class="mono">64</td><td data-i18n="dRepeatLastN"></td></tr>
+              <tr><td><code>frequency_penalty</code></td><td class="mono">0.0 - 2.0</td><td class="mono">0.0</td><td data-i18n="dFreqPenalty"></td></tr>
+              <tr><td><code>presence_penalty</code></td><td class="mono">0.0 - 2.0</td><td class="mono">0.0</td><td data-i18n="dPresPenalty"></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Context -->
+      <section class="mb-10">
+        <h2 class="text-2xl font-bold text-ai-purple mb-2 flex items-center gap-2">
+          <span>&#x1F4D0;</span><span data-i18n="hContext">Contexto</span>
+        </h2>
+        <p class="text-gray-400 text-sm mb-4" data-i18n="contextDesc"></p>
+        <div class="rounded-xl border border-border-default bg-bg-tertiary/30 overflow-x-auto">
+          <table class="param-table">
+            <thead>
+              <tr>
+                <th data-i18n="thParam">Parametro</th>
+                <th data-i18n="thRange">Rango</th>
+                <th data-i18n="thDefault">Default</th>
+                <th data-i18n="thDesc">Descripcion</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td><code>context_size</code></td><td class="mono">512 - 32768</td><td class="mono">4096</td><td data-i18n="dContextSize"></td></tr>
+              <tr><td><code>response_reserve</code></td><td class="mono">64 - 1024</td><td class="mono">256</td><td data-i18n="dResponseReserve"></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Advanced -->
+      <section class="mb-10">
+        <h2 class="text-2xl font-bold text-ai-purple mb-2 flex items-center gap-2">
+          <span>&#x2699;&#xFE0F;</span><span data-i18n="hAdvanced">Avanzado</span>
+        </h2>
+        <p class="text-gray-400 text-sm mb-4" data-i18n="advancedDesc"></p>
+        <div class="rounded-xl border border-border-default bg-bg-tertiary/30 overflow-x-auto">
+          <table class="param-table">
+            <thead>
+              <tr>
+                <th data-i18n="thParam">Parametro</th>
+                <th data-i18n="thRange">Rango</th>
+                <th data-i18n="thDefault">Default</th>
+                <th data-i18n="thDesc">Descripcion</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td><code>seed</code></td><td class="mono">-1 - &#x221E;</td><td class="mono">-1</td><td data-i18n="dSeed"></td></tr>
+              <tr><td><code>mirostat</code></td><td class="mono">0 - 2</td><td class="mono">0</td><td data-i18n="dMirostat"></td></tr>
+              <tr><td><code>mirostat_tau</code></td><td class="mono">0.0 - 10.0</td><td class="mono">5.0</td><td data-i18n="dMirostatTau"></td></tr>
+              <tr><td><code>mirostat_eta</code></td><td class="mono">0.0 - 1.0</td><td class="mono">0.1</td><td data-i18n="dMirostatEta"></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Presets -->
+      <section class="mb-10">
+        <h2 class="text-2xl font-bold text-ai-green mb-2 flex items-center gap-2">
+          <span>&#x1F3AF;</span><span data-i18n="hPresets">Presets Built-in</span>
+        </h2>
+        <p class="text-gray-400 text-sm mb-4" data-i18n="presetsDesc"></p>
+        <div class="rounded-xl border border-border-default bg-bg-tertiary/30 overflow-x-auto">
+          <table class="param-table">
+            <thead>
+              <tr>
+                <th data-i18n="thPreset">Preset</th>
+                <th><code>temperature</code></th>
+                <th><code>top_p</code></th>
+                <th><code>top_k</code></th>
+                <th><code>min_p</code></th>
+                <th><code>repeat_penalty</code></th>
+                <th><code>max_tokens</code></th>
+                <th data-i18n="thUseCase">Caso de uso</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td class="mono">Creative</td><td class="mono">1.0</td><td class="mono">0.95</td><td class="mono">50</td><td class="mono">0.02</td><td class="mono">1.15</td><td class="mono">512</td><td data-i18n="ucCreative"></td></tr>
+              <tr><td class="mono">Balanced</td><td class="mono">0.7</td><td class="mono">0.9</td><td class="mono">40</td><td class="mono">0.05</td><td class="mono">1.1</td><td class="mono">256</td><td data-i18n="ucBalanced"></td></tr>
+              <tr><td class="mono">Consistent</td><td class="mono">0.3</td><td class="mono">0.8</td><td class="mono">20</td><td class="mono">0.1</td><td class="mono">1.05</td><td class="mono">256</td><td data-i18n="ucConsistent"></td></tr>
+              <tr><td class="mono">Roleplay</td><td class="mono">0.8</td><td class="mono">0.92</td><td class="mono">45</td><td class="mono">0.04</td><td class="mono">1.12</td><td class="mono">384</td><td data-i18n="ucRoleplay"></td></tr>
+              <tr><td class="mono">Technical</td><td class="mono">0.2</td><td class="mono">0.7</td><td class="mono">10</td><td class="mono">0.15</td><td class="mono">1.0</td><td class="mono">512</td><td data-i18n="ucTechnical"></td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-gray-500 text-xs mt-2 font-mono">Roleplay: presence_penalty = 0.3</p>
+      </section>
+
+      <!-- Tips -->
+      <section class="mb-10">
+        <h2 class="text-2xl font-bold text-warning mb-4 flex items-center gap-2">
+          <span>&#x1F4A1;</span><span data-i18n="hTips">Tips practicos</span>
+        </h2>
+        <ul class="space-y-2 text-gray-300 text-sm list-disc pl-6">
+          <li data-i18n="tip1"></li>
+          <li data-i18n="tip2"></li>
+          <li data-i18n="tip3"></li>
+          <li data-i18n="tip4"></li>
+          <li data-i18n="tip5"></li>
+        </ul>
+      </section>
+
+      <!-- Related -->
+      <section class="mb-12">
+        <h2 class="text-2xl font-bold text-ai-cyan mb-4 flex items-center gap-2">
+          <span>&#x1F517;</span><span data-i18n="hRelated">Relacionado</span>
+        </h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <a href="../API/resources.html"
+            class="p-4 rounded-xl border border-border-default bg-bg-tertiary/30 hover:border-ai-cyan/50 transition-colors group">
+            <div class="text-xl mb-2 group-hover:scale-110 transition-transform">&#x1F4C4;</div>
+            <h3 class="font-bold text-white group-hover:text-ai-cyan transition-colors">Resources</h3>
+            <p class="text-gray-500 text-sm mt-1" data-i18n="relResources">Referencia de AIPreset y ModelConfig.</p>
+          </a>
+          <a href="first-npc.html"
+            class="p-4 rounded-xl border border-border-default bg-bg-tertiary/30 hover:border-ai-purple/50 transition-colors group">
+            <div class="text-xl mb-2 group-hover:scale-110 transition-transform">&#x1F3AE;</div>
+            <h3 class="font-bold text-white group-hover:text-ai-purple transition-colors">First NPC</h3>
+            <p class="text-gray-500 text-sm mt-1" data-i18n="relFirstNpc">Aplica un preset a tu primer NPC.</p>
+          </a>
+        </div>
+      </section>
+
+      <!-- Back Link -->
+      <div class="mt-12 pt-8 border-t border-border-default">
+        <a href="index.html"
+          class="inline-flex items-center gap-2 text-ai-cyan hover:text-ai-pink transition-colors font-mono">
+          <span>&#x2190;</span>
+          <span data-i18n="backToGuides">Volver a Guides</span>
+        </a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="mt-16 pt-8 border-t border-border-default text-center text-gray-500 text-sm relative">
+        <span
+          class="absolute -top-3 left-1/2 -translate-x-1/2 bg-bg-primary px-4 text-ai-purple text-xs tracking-widest">&#x2726;
+          &#x2726; &#x2726;</span>
+        <p>OhMyDialogSystem Wiki | <a href="https://github.com/lobinuxsoft/OhMyDialogSystem" target="_blank"
+            class="text-ai-cyan hover:text-ai-pink">GitHub</a></p>
+        <p class="mt-1">Apache 2.0 License - Made with &#x1F9E0; by lobinuxsoft</p>
+      </footer>
+    </main>
+  </div>
+  <script src="../ai-bg.js"></script>
+</body>
+
+</html>

--- a/docs/Guides/tts-setup.html
+++ b/docs/Guides/tts-setup.html
@@ -119,6 +119,9 @@
           <div class="text-xs uppercase tracking-widest text-ai-purple mb-2 pl-2 flex items-center gap-2 font-mono"><span class="text-gray-600 text-[0.65rem]">//</span> Guides</div>
           <ul>
             <li><a href="character-identity.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm bg-gradient-to-r from-ai-cyan/10 to-transparent text-ai-cyan border-l-2 border-ai-cyan"><span class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>
             <li><a href="csharp-bindings.html" class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span class="opacity-70">&#x1F537;</span> C# Bindings</a></li>
           </ul>

--- a/docs/Guides/visual-editor.html
+++ b/docs/Guides/visual-editor.html
@@ -291,6 +291,9 @@
             <li><a href="character-identity.html"
                 class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
                   class="opacity-70">&#x1F464;</span> Character Identity</a></li>
+            <li><a href="sampling-parameters.html"
+                class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
+                  class="opacity-70">&#x1F39B;&#xFE0F;</span> Sampling Parameters</a></li>
             <li><a href="tts-setup.html"
                 class="flex items-center gap-2 py-2 px-4 rounded-md text-sm text-gray-400 hover:bg-bg-tertiary hover:text-ai-cyan transition-all"><span
                   class="opacity-70">&#x1F3A4;</span> TTS Setup</a></li>

--- a/docs/components/sidebar.html
+++ b/docs/components/sidebar.html
@@ -51,6 +51,7 @@ const sidebarData = {
           { href: 'Guides/index.html', icon: '\uD83D\uDCD6', text: 'Overview' },
           { href: 'Guides/visual-editor.html', icon: '\uD83C\uDFA8', text: 'Editor Visual' },
           { href: 'Guides/character-identity.html', icon: '\uD83D\uDC64', text: 'Character Identity' },
+          { href: 'Guides/sampling-parameters.html', icon: '\uD83C\uDF9B\uFE0F', text: 'Sampling Parameters' },
           { href: 'Guides/tts-setup.html', icon: '\uD83C\uDFA4', text: 'TTS Setup' },
           { href: 'Guides/csharp-bindings.html', icon: '\uD83D\uDD37', text: 'C# Bindings' }
         ]
@@ -120,6 +121,7 @@ const sidebarData = {
           { href: 'Guides/index.html', icon: '\uD83D\uDCD6', text: 'Overview' },
           { href: 'Guides/visual-editor.html', icon: '\uD83C\uDFA8', text: 'Visual Editor' },
           { href: 'Guides/character-identity.html', icon: '\uD83D\uDC64', text: 'Character Identity' },
+          { href: 'Guides/sampling-parameters.html', icon: '\uD83C\uDF9B\uFE0F', text: 'Sampling Parameters' },
           { href: 'Guides/tts-setup.html', icon: '\uD83C\uDFA4', text: 'TTS Setup' },
           { href: 'Guides/csharp-bindings.html', icon: '\uD83D\uDD37', text: 'C# Bindings' }
         ]


### PR DESCRIPTION
## Qué

Nueva página de wiki `docs/Guides/sampling-parameters.html` documentando los **17 parámetros de generación** del `AIPreset`:

- **Temperature & Sampling**: temperature, top_p, top_k, min_p, typical_p
- **Output**: max_tokens, stop_sequences
- **Repetition**: repeat_penalty, repeat_last_n, frequency_penalty, presence_penalty
- **Context**: context_size, response_reserve
- **Advanced**: seed, mirostat, mirostat_tau, mirostat_eta

Cada uno con rango válido, default y descripción (valores tomados directo de `resources/ai_preset.gd`). Incluye tabla con los valores reales de los **5 presets built-in** (Creative/Balanced/Consistent/Roleplay/Technical) y tips prácticos.

## Cómo

- Patrón visual idéntico al resto de la wiki (Tailwind + neural-bg + i18n ES/EN).
- Enlazada en la sección **Guides** del sidebar de las 11 páginas de `docs/Guides/` + el sidebar canónico `components/sidebar.html`.
- Cross-links a `resources.html` y `first-npc.html`.

## Nota

El sidebar está duplicado inline en cada página (deuda preexistente; `components/sidebar.html` está huérfano). Esta PR solo propaga el link dentro de `Guides/`, no a API/Technical, para mantener el scope acotado.

Closes #63