### PR TITLE
docs(wiki): documentar la API real contra el código (26 anclas rotas, 3 familias sin documentar)

### DIFF
--- a/addons/ohmydialog/core/token_counter.gd.uid
+++ b/addons/ohmydialog/core/token_counter.gd.uid
@@ -1,0 +1,1 @@
+uid://b8kvbx3yx8oij

--- a/docs/API/dialogue-manager.html
+++ b/docs/API/dialogue-manager.html
@@ -98,7 +98,25 @@
           sigCondQuery: 'El diálogo necesita verificar una condición. Llamar callback.call(result: bool).',
           sigActionQuery: 'El diálogo necesita ejecutar una acción. Llamar callback.call() cuando termine.',
           sigValueQuery: 'El diálogo necesita obtener un valor. Llamar callback.call(value).',
-          sigError: 'Emitida cuando ocurre un error durante la ejecución'
+          sigError: 'Emitida cuando ocurre un error durante la ejecución',
+          // Metodos sin seccion previa
+          endDialogueDesc: 'Termina la sesión activa. No hace nada si no hay ninguna.',
+          endDialogueNote: 'Espera a que el hilo de inferencia termine y SIEMPRE descarga el modelo para liberar memoria. El parámetro reason viaja tal cual en la señal dialogue_ended.',
+          selectChoiceDesc: 'Elige una de las opciones ofrecidas por player_choices_available, por índice. Avisa por consola si no hay diálogo activo.',
+          setCharacterDesc: 'Cambia el personaje activo para las respuestas de IA, en caliente.',
+          setWorldContextDesc: 'Cambia el contexto de mundo usado al construir el prompt.',
+          setStreamingDesc: 'Activa o desactiva el streaming token a token. Con streaming apagado la respuesta llega entera por npc_response_completed.',
+          isActiveDesc: 'True entre start_dialogue y end_dialogue.',
+          setVariableDesc: 'Escribe una variable del contexto. scope acepta "local" (se borra al terminar el diálogo) o "global" (persiste).',
+          evaluateConditionDesc: 'Evalúa una expresión contra las variables del contexto y devuelve el resultado.',
+          getHistoryDesc: 'El ConversationHistory de la sesión: los turnos de jugador y NPC que se están usando como contexto.',
+          getContextManagerDesc: 'El ContextManager, dueño de las variables locales y globales.',
+          clearHistoryDesc: 'Borra el historial de conversación sin terminar el diálogo. El modelo sigue cargado.',
+          queryActionDesc: 'Pide al juego que ejecute una acción. Emite action_query_requested y espera el callback.',
+          queryValueDesc: 'Pide al juego un valor. Emite value_query_requested y espera el callback.',
+          queryNoHandler: 'Si no hay nadie conectado a la señal, query_action devuelve false y query_value devuelve default_value. El diálogo no se cuelga esperando.',
+          deprecatedTitle: 'Obsoleto',
+          setAiPresetDep: 'set_ai_preset() está marcado como obsoleto en el código y emite un warning: el preset se define en DialogueGraph.ai_preset.'
         },
         en: {
           navInstallation: 'Installation', navFirstNpc: 'Your First NPC', navArchitecture: 'Architecture',
@@ -180,7 +198,25 @@
           sigCondQuery: 'Dialogue needs to verify a condition. Call callback.call(result: bool).',
           sigActionQuery: 'Dialogue needs to execute an action. Call callback.call() when finished.',
           sigValueQuery: 'Dialogue needs to get a value. Call callback.call(value).',
-          sigError: 'Emitted when an execution error occurs'
+          sigError: 'Emitted when an execution error occurs',
+          // Methods with no previous section
+          endDialogueDesc: 'Ends the active session. Does nothing when there is none.',
+          endDialogueNote: 'It waits for the inference thread to finish and ALWAYS unloads the model to free memory. The reason parameter travels as-is in the dialogue_ended signal.',
+          selectChoiceDesc: 'Picks one of the options offered by player_choices_available, by index. Warns on the console when no dialogue is active.',
+          setCharacterDesc: 'Swaps the active character for AI responses, at runtime.',
+          setWorldContextDesc: 'Swaps the world context used when building the prompt.',
+          setStreamingDesc: 'Turns token-by-token streaming on or off. With streaming off the response arrives whole through npc_response_completed.',
+          isActiveDesc: 'True between start_dialogue and end_dialogue.',
+          setVariableDesc: 'Writes a context variable. scope accepts "local" (cleared when the dialogue ends) or "global" (persists).',
+          evaluateConditionDesc: 'Evaluates an expression against the context variables and returns the result.',
+          getHistoryDesc: 'The session ConversationHistory: the player and NPC turns currently used as context.',
+          getContextManagerDesc: 'The ContextManager, owner of the local and global variables.',
+          clearHistoryDesc: 'Clears the conversation history without ending the dialogue. The model stays loaded.',
+          queryActionDesc: 'Asks the game to run an action. Emits action_query_requested and waits for the callback.',
+          queryValueDesc: 'Asks the game for a value. Emits value_query_requested and waits for the callback.',
+          queryNoHandler: 'When nothing is connected to the signal, query_action returns false and query_value returns default_value. The dialogue does not hang waiting.',
+          deprecatedTitle: 'Deprecated',
+          setAiPresetDep: 'set_ai_preset() is marked deprecated in the code and emits a warning: the preset is set on DialogueGraph.ai_preset.'
         }
       },
       init() {
@@ -926,6 +962,107 @@
           class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">bool</span> query_condition(key: <span class="text-ai-cyan">String</span>, expected: <span class="text-ai-cyan">Variant</span> = true, default: <span class="text-ai-cyan">bool</span> = false)</code></pre>
         <p class="text-gray-400 mb-4" data-i18n="queryConditionDesc">Consulta una condición al código del juego. Emite
           condition_query_requested y espera respuesta.</p>
+      </div>
+
+      <div id="end_dialogue" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">end_dialogue</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> end_dialogue(reason: <span class="text-ai-cyan">String</span> = "ended")</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="endDialogueDesc">Termina la sesión activa. No hace nada si no hay ninguna.</p>
+        <div class="p-4 rounded-lg border border-warning/30 bg-warning/5 mb-4">
+          <p class="text-gray-300 text-sm" data-i18n="endDialogueNote">Espera a que el hilo de inferencia termine y SIEMPRE descarga el modelo para liberar memoria. El parámetro reason viaja tal cual en la señal dialogue_ended.</p>
+        </div>
+      </div>
+
+      <div id="select_choice" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">select_choice</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> select_choice(choice_index: <span class="text-ai-cyan">int</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="selectChoiceDesc">Elige una de las opciones ofrecidas por player_choices_available, por índice. Avisa por consola si no hay diálogo activo.</p>
+      </div>
+
+      <div id="is_active" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">is_active</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">bool</span> is_active()</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="isActiveDesc">True entre start_dialogue y end_dialogue.</p>
+      </div>
+
+      <div id="set_character" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">set_character</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> set_character(character: <span class="text-ai-cyan">CharacterIdentity</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="setCharacterDesc">Cambia el personaje activo para las respuestas de IA, en caliente.</p>
+      </div>
+
+      <div id="set_world_context" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">set_world_context</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> set_world_context(context: <span class="text-ai-cyan">WorldContext</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="setWorldContextDesc">Cambia el contexto de mundo usado al construir el prompt.</p>
+        <div class="p-4 rounded-lg border border-warning/30 bg-warning/5 mb-4">
+          <p class="text-warning font-bold text-sm mb-1" data-i18n="deprecatedTitle">Obsoleto</p>
+          <p class="text-gray-300 text-sm" data-i18n="setAiPresetDep">set_ai_preset() está marcado como obsoleto en el código y emite un warning: el preset se define en DialogueGraph.ai_preset.</p>
+        </div>
+      </div>
+
+      <div id="set_streaming_enabled" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">set_streaming_enabled</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> set_streaming_enabled(enabled: <span class="text-ai-cyan">bool</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="setStreamingDesc">Activa o desactiva el streaming token a token. Con streaming apagado la respuesta llega entera por npc_response_completed.</p>
+      </div>
+
+      <div id="set_variable" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">set_variable</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> set_variable(name: <span class="text-ai-cyan">String</span>, value: <span class="text-ai-cyan">Variant</span>, scope: <span class="text-ai-cyan">String</span> = "local")</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="setVariableDesc">Escribe una variable del contexto. scope acepta "local" (se borra al terminar el diálogo) o "global" (persiste).</p>
+      </div>
+
+      <div id="evaluate_condition" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">evaluate_condition</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">bool</span> evaluate_condition(expression: <span class="text-ai-cyan">String</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="evaluateConditionDesc">Evalúa una expresión contra las variables del contexto y devuelve el resultado.</p>
+      </div>
+
+      <div id="query_action" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">query_action</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">bool</span> query_action(key: <span class="text-ai-cyan">String</span>, value: <span class="text-ai-cyan">Variant</span> = null)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="queryActionDesc">Pide al juego que ejecute una acción. Emite action_query_requested y espera el callback.</p>
+      </div>
+
+      <div id="query_value" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">query_value</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">Variant</span> query_value(key: <span class="text-ai-cyan">String</span>, default_value: <span class="text-ai-cyan">Variant</span> = null)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="queryValueDesc">Pide al juego un valor. Emite value_query_requested y espera el callback.</p>
+        <div class="p-4 rounded-lg border border-ai-cyan/30 bg-ai-cyan/5 mb-4">
+          <p class="text-gray-300 text-sm" data-i18n="queryNoHandler">Si no hay nadie conectado a la señal, query_action devuelve false y query_value devuelve default_value. El diálogo no se cuelga esperando.</p>
+        </div>
+      </div>
+
+      <div id="get_conversation_history" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">get_conversation_history</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">ConversationHistory</span> get_conversation_history()</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="getHistoryDesc">El ConversationHistory de la sesión: los turnos de jugador y NPC que se están usando como contexto.</p>
+      </div>
+
+      <div id="get_context_manager" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">get_context_manager</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">ContextManager</span> get_context_manager()</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="getContextManagerDesc">El ContextManager, dueño de las variables locales y globales.</p>
+      </div>
+
+      <div id="clear_history" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">clear_history</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> clear_history()</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="clearHistoryDesc">Borra el historial de conversación sin terminar el diálogo. El modelo sigue cargado.</p>
       </div>
 
       <div id="get_debug_info" class="mb-12">

--- a/docs/API/llama-interface.html
+++ b/docs/API/llama-interface.html
@@ -44,7 +44,23 @@
           paramsTitle: 'Parámetros',
           pTableParam: 'Parámetro', pTableType: 'Tipo', pTableDesc: 'Descripción',
           paramPathDesc: 'Ruta al archivo .gguf. Soporta res:// y user://',
-          paramParamsDesc: 'Parámetros opcionales de configuración'
+          paramParamsDesc: 'Parámetros opcionales de configuración',
+          paramsKeysTitle: 'Claves aceptadas en params',
+          pNGpuLayers: 'Capas a descargar en GPU. Por defecto 999 (todas las que entren)',
+          pNCtx: 'Tamaño de la ventana de contexto, en tokens. Por defecto 512',
+          pNBatch: 'Tamaño de lote para el procesado del prompt',
+          pNThreads: 'Hilos de CPU para generación',
+          pNThreadsBatch: 'Hilos de CPU para el procesado del prompt',
+          pUseMmap: 'Mapear el archivo en memoria en vez de leerlo entero',
+          pUseMlock: 'Forzar al sistema a mantener el modelo en RAM',
+          pVocabOnly: 'Cargar SOLO el vocabulario, sin los pesos. Ver "Tokenizar sin cargar el modelo"',
+          countTokensDesc: 'Devuelve la cantidad exacta de tokens que ocupa el texto, según el vocabulario del modelo. Devuelve -1 si no hay modelo cargado.',
+          countTokensWhy: 'Por qué importa',
+          countTokensWhyText: 'La regla de ~4 caracteres por token se rompe con tildes, ñ y emojis: en español subestima el costo real. Este método usa el tokenizador del propio modelo.',
+          vocabOnlyTitle: 'Tokenizar sin cargar el modelo',
+          vocabOnlyIntro: 'Contar tokens sólo necesita el vocabulario, no los pesos ni el contexto. Con vocab_only el modelo se abre sin leer un solo tensor y sin reservar KV cache: cuesta megabytes en vez de gigabytes.',
+          vocabOnlyNote: 'El addon ya hace esto por vos: TokenCounter (core/token_counter.gd) cachea un handle por ruta de modelo y lo usa el editor para mostrar el costo real de cada nodo AI Response.',
+          vocabOnlyWarn: 'Un handle vocab_only sirve para tokenizar, NO para generar. Además deja n_ctx_train sin poblar, así que el tamaño de contexto del archivo no se puede leer por esta vía.'
         },
         en: {
           navInstallation: 'Installation', navFirstNpc: 'Your First NPC', navArchitecture: 'Architecture',
@@ -72,7 +88,23 @@
           paramsTitle: 'Parameters',
           pTableParam: 'Parameter', pTableType: 'Type', pTableDesc: 'Description',
           paramPathDesc: 'Path to .gguf file. Supports res:// and user://',
-          paramParamsDesc: 'Optional configuration parameters'
+          paramParamsDesc: 'Optional configuration parameters',
+          paramsKeysTitle: 'Keys accepted in params',
+          pNGpuLayers: 'Layers to offload to the GPU. Defaults to 999 (as many as fit)',
+          pNCtx: 'Context window size, in tokens. Defaults to 512',
+          pNBatch: 'Batch size for prompt processing',
+          pNThreads: 'CPU threads for generation',
+          pNThreadsBatch: 'CPU threads for prompt processing',
+          pUseMmap: 'Memory-map the file instead of reading it whole',
+          pUseMlock: 'Force the system to keep the model in RAM',
+          pVocabOnly: 'Load ONLY the vocabulary, no weights. See "Tokenizing without loading the model"',
+          countTokensDesc: 'Returns the exact number of tokens the text takes, according to the model vocabulary. Returns -1 when no model is loaded.',
+          countTokensWhy: 'Why it matters',
+          countTokensWhyText: 'The ~4 characters per token rule breaks on accents, ñ and emoji: in Spanish it underestimates the real cost. This method uses the model own tokenizer.',
+          vocabOnlyTitle: 'Tokenizing without loading the model',
+          vocabOnlyIntro: 'Counting tokens only needs the vocabulary, not the weights nor the context. With vocab_only the model opens without reading a single tensor and without allocating a KV cache: it costs megabytes instead of gigabytes.',
+          vocabOnlyNote: 'The addon already does this for you: TokenCounter (core/token_counter.gd) caches a handle per model path and the editor uses it to show the real cost of every AI Response node.',
+          vocabOnlyWarn: 'A vocab_only handle is for tokenizing, NOT for generating. It also leaves n_ctx_train unpopulated, so the context size of the file cannot be read this way.'
         }
       },
       init() {
@@ -489,6 +521,111 @@ llama.load_model(<span class="text-ai-orange">"res://models/model.gguf"</span>)<
               </tr>
             </tbody>
           </table>
+        </div>
+
+        <h5 class="text-sm font-bold text-gray-300 mb-2 uppercase tracking-wider" data-i18n="paramsKeysTitle">Claves
+          aceptadas en params</h5>
+        <div class="overflow-x-auto mb-4">
+          <table class="w-full border-collapse">
+            <thead>
+              <tr class="border-b border-border-default">
+                <th class="text-left py-2 px-4 text-ai-cyan text-sm" data-i18n="pTableParam">Parámetro</th>
+                <th class="text-left py-2 px-4 text-ai-cyan text-sm" data-i18n="pTableType">Tipo</th>
+                <th class="text-left py-2 px-4 text-ai-cyan text-sm" data-i18n="pTableDesc">Descripción</th>
+              </tr>
+            </thead>
+            <tbody class="text-sm">
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_gpu_layers</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="pNGpuLayers">Capas a descargar en GPU. Por defecto 999
+                  (todas las que entren)</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_ctx</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="pNCtx">Tamaño de la ventana de contexto, en tokens. Por
+                  defecto 512</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_batch</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="pNBatch">Tamaño de lote para el procesado del prompt</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_threads</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="pNThreads">Hilos de CPU para generación</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_threads_batch</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="pNThreadsBatch">Hilos de CPU para el procesado del prompt
+                </td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">use_mmap</td>
+                <td class="py-2 px-4 font-mono text-gray-400">bool</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="pUseMmap">Mapear el archivo en memoria en vez de leerlo
+                  entero</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">use_mlock</td>
+                <td class="py-2 px-4 font-mono text-gray-400">bool</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="pUseMlock">Forzar al sistema a mantener el modelo en RAM
+                </td>
+              </tr>
+              <tr>
+                <td class="py-2 px-4 font-mono text-ai-green">vocab_only</td>
+                <td class="py-2 px-4 font-mono text-gray-400">bool</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="pVocabOnly">Cargar SOLO el vocabulario, sin los pesos. Ver
+                  "Tokenizar sin cargar el modelo"</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- count_tokens -->
+      <div id="count_tokens" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">count_tokens</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">int</span> count_tokens(text: <span class="text-ai-cyan">String</span>) const</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="countTokensDesc">Devuelve la cantidad exacta de tokens que ocupa el
+          texto, según el vocabulario del modelo. Devuelve -1 si no hay modelo cargado.</p>
+
+        <div class="p-4 rounded-lg border border-warning/30 bg-warning/5 mb-6">
+          <p class="text-warning font-bold text-sm mb-1" data-i18n="countTokensWhy">Por qué importa</p>
+          <p class="text-gray-300 text-sm" data-i18n="countTokensWhyText">La regla de ~4 caracteres por token se rompe
+            con tildes, ñ y emojis: en español subestima el costo real. Este método usa el tokenizador del propio
+            modelo.</p>
+        </div>
+
+        <h5 class="text-lg font-bold text-ai-green mb-3" data-i18n="vocabOnlyTitle">Tokenizar sin cargar el modelo</h5>
+        <p class="text-gray-400 mb-4" data-i18n="vocabOnlyIntro">Contar tokens sólo necesita el vocabulario, no los pesos
+          ni el contexto. Con vocab_only el modelo se abre sin leer un solo tensor y sin reservar KV cache: cuesta
+          megabytes en vez de gigabytes.</p>
+
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">var</span> llama := <span class="text-ai-cyan">LlamaInterface</span>.new()
+llama.<span class="text-ai-cyan">load_model</span>(<span class="text-ai-green">"res://models/qwen2.5-3b-instruct-q4_k_m.gguf"</span>, {
+    <span class="text-ai-green">"vocab_only"</span>: <span class="text-ai-purple">true</span>,
+    <span class="text-ai-green">"n_gpu_layers"</span>: <span class="text-ai-purple">0</span>,
+    <span class="text-ai-green">"n_ctx"</span>: <span class="text-ai-purple">512</span>,
+})
+
+<span class="text-ai-purple">var</span> tokens := llama.<span class="text-ai-cyan">count_tokens</span>(<span class="text-ai-green">"¿Cuántos tokens ocupa esta frase?"</span>)</code></pre>
+
+        <div class="p-4 rounded-lg border border-ai-cyan/30 bg-ai-cyan/5 mb-4">
+          <p class="text-gray-300 text-sm" data-i18n="vocabOnlyNote">El addon ya hace esto por vos: TokenCounter
+            (core/token_counter.gd) cachea un handle por ruta de modelo y lo usa el editor para mostrar el costo real de
+            cada nodo AI Response.</p>
+        </div>
+
+        <div class="p-4 rounded-lg border border-error/30 bg-error/5">
+          <p class="text-gray-300 text-sm" data-i18n="vocabOnlyWarn">Un handle vocab_only sirve para tokenizar, NO para
+            generar. Además deja n_ctx_train sin poblar, así que el tamaño de contexto del archivo no se puede leer por
+            esta vía.</p>
         </div>
       </div>
 

--- a/docs/API/llama-interface.html
+++ b/docs/API/llama-interface.html
@@ -60,7 +60,42 @@
           vocabOnlyTitle: 'Tokenizar sin cargar el modelo',
           vocabOnlyIntro: 'Contar tokens sólo necesita el vocabulario, no los pesos ni el contexto. Con vocab_only el modelo se abre sin leer un solo tensor y sin reservar KV cache: cuesta megabytes en vez de gigabytes.',
           vocabOnlyNote: 'El addon ya hace esto por vos: TokenCounter (core/token_counter.gd) cachea un handle por ruta de modelo y lo usa el editor para mostrar el costo real de cada nodo AI Response.',
-          vocabOnlyWarn: 'Un handle vocab_only sirve para tokenizar, NO para generar. Además deja n_ctx_train sin poblar, así que el tamaño de contexto del archivo no se puede leer por esta vía.'
+          vocabOnlyWarn: 'Un handle vocab_only sirve para tokenizar, NO para generar. Además deja n_ctx_train sin poblar, así que el tamaño de contexto del archivo no se puede leer por esta vía.',
+          unloadModelDesc: 'Libera el modelo, el contexto y el sampler. No hace nada si no hay modelo cargado.',
+          isModelLoadedDesc: 'Devuelve true sólo cuando el modelo Y el contexto existen. Un handle a medio construir da false.',
+          getModelInfoDesc: 'Metadatos del modelo cargado. Devuelve un Dictionary vacío si no hay ninguno.',
+          getModelInfoKeys: 'Claves devueltas',
+          getModelInfoNote: 'bos_token y eos_token sólo aparecen si el modelo los define. chat_template sólo si el GGUF trae plantilla embebida.',
+          getModelPathDesc: 'Ruta del modelo cargado, tal cual se pasó a load_model. Cadena vacía si no hay ninguno.',
+          getSystemInfoDesc: 'Cadena de llama.cpp con las capacidades de CPU detectadas (AVX, NEON, etc.). Útil para reportes de bug.',
+          getChatTemplateDesc: 'Plantilla de chat embebida en el GGUF, en formato Jinja. Cadena vacía si el modelo no trae ninguna o no hay modelo cargado.',
+          applyChatTemplateDesc: 'Aplica la plantilla del modelo a una lista de mensajes y devuelve el prompt final.',
+          paramMessagesDesc: 'Array de Dictionary con las claves role y content. Los que no tengan ambas se descartan con un warning.',
+          paramAddGenDesc: 'Añade el encabezado que le indica al modelo que empiece a responder',
+          generateDesc: 'Genera la respuesta completa y la devuelve. Cadena vacía ante cualquier error.',
+          generateWarn: 'Bloquea el hilo que la llama',
+          generateWarnText: 'Llamada desde el hilo principal, congela el juego hasta el último token. Para gameplay usá generate_async o generate_streaming.',
+          generateAsyncDesc: 'Genera en el WorkerThreadPool y entrega el texto por generation_completed. No devuelve nada.',
+          generateStreamingDesc: 'Igual que generate_async, pero además emite token_generated por cada token a medida que sale.',
+          genSharedNote: 'Ambas emiten generation_started al arrancar. Si ya hay una generación en curso, avisan por consola y no hacen nada. Sin modelo cargado emiten generation_error.',
+          isGeneratingDesc: 'True mientras hay una generación async o streaming en curso. Es atómico: se puede consultar desde cualquier hilo.',
+          getProgressDesc: 'Progreso de 0.0 a 1.0, calculado como tokens emitidos sobre max_tokens. Devuelve 0.0 si no se está generando.',
+          getProgressNote: 'Es un progreso contra el techo, no contra la respuesta real: si el modelo termina antes de max_tokens, nunca llega a 1.0.',
+          cancelDesc: 'Pide abortar la generación en curso. No hace nada si no hay ninguna.',
+          cancelWarn: 'Espera a que el worker termine',
+          cancelWarnText: 'Esta llamada bloquea hasta que la tarea se detiene de verdad. Es lo que garantiza que no queden hilos sueltos, pero significa que cancelar desde el hilo principal cuesta un frame corto.',
+          propsTitle: 'Propiedades',
+          propsIntro: 'Expuestas como propiedades del objeto, con setter y getter. Se pueden asignar directo.',
+          propsNote: 'frequency_penalty, presence_penalty y repeat_last_n existen sólo como métodos (set_/get_), no como propiedades: hay que llamarlos, no asignarlos.',
+          signalsTitle: 'Señales',
+          sigStarted: 'Emitida al arrancar una generación async o streaming.',
+          sigToken: 'Un token recién generado, sólo en generate_streaming. Llega en el hilo principal.',
+          sigCompleted: 'Respuesta completa, al terminar una generación async o streaming.',
+          sigError: 'Algo falló: sin modelo cargado, prompt más largo que el contexto, o error de decodificación.',
+          sigProgress: 'Progreso de 0.0 a 1.0 durante la generación.',
+          sigCancelled: 'Emitida cuando cancel_generation detiene la generación.',
+          sigTimeout: 'El tiempo configurado con set_timeout se agotó y la generación se cortó.',
+          tblType: 'Tipo', tblKey: 'Clave', tblSignal: 'Señal', tblProp: 'Propiedad', tblRange: 'Rango'
         },
         en: {
           navInstallation: 'Installation', navFirstNpc: 'Your First NPC', navArchitecture: 'Architecture',
@@ -104,7 +139,42 @@
           vocabOnlyTitle: 'Tokenizing without loading the model',
           vocabOnlyIntro: 'Counting tokens only needs the vocabulary, not the weights nor the context. With vocab_only the model opens without reading a single tensor and without allocating a KV cache: it costs megabytes instead of gigabytes.',
           vocabOnlyNote: 'The addon already does this for you: TokenCounter (core/token_counter.gd) caches a handle per model path and the editor uses it to show the real cost of every AI Response node.',
-          vocabOnlyWarn: 'A vocab_only handle is for tokenizing, NOT for generating. It also leaves n_ctx_train unpopulated, so the context size of the file cannot be read this way.'
+          vocabOnlyWarn: 'A vocab_only handle is for tokenizing, NOT for generating. It also leaves n_ctx_train unpopulated, so the context size of the file cannot be read this way.',
+          unloadModelDesc: 'Frees the model, the context and the sampler. Does nothing when no model is loaded.',
+          isModelLoadedDesc: 'Returns true only when both the model AND the context exist. A half-built handle returns false.',
+          getModelInfoDesc: 'Metadata of the loaded model. Returns an empty Dictionary when there is none.',
+          getModelInfoKeys: 'Returned keys',
+          getModelInfoNote: 'bos_token and eos_token only appear when the model defines them. chat_template only when the GGUF ships an embedded template.',
+          getModelPathDesc: 'Path of the loaded model, exactly as passed to load_model. Empty string when there is none.',
+          getSystemInfoDesc: 'llama.cpp string with the detected CPU capabilities (AVX, NEON, etc.). Useful for bug reports.',
+          getChatTemplateDesc: 'Chat template embedded in the GGUF, in Jinja format. Empty string when the model ships none or no model is loaded.',
+          applyChatTemplateDesc: 'Applies the model template to a list of messages and returns the final prompt.',
+          paramMessagesDesc: 'Array of Dictionary with the keys role and content. Entries missing either one are skipped with a warning.',
+          paramAddGenDesc: 'Appends the header that tells the model to start answering',
+          generateDesc: 'Generates the full response and returns it. Empty string on any error.',
+          generateWarn: 'Blocks the calling thread',
+          generateWarnText: 'Called from the main thread, it freezes the game until the last token. For gameplay use generate_async or generate_streaming.',
+          generateAsyncDesc: 'Generates on the WorkerThreadPool and delivers the text through generation_completed. Returns nothing.',
+          generateStreamingDesc: 'Same as generate_async, but it also emits token_generated for every token as it comes out.',
+          genSharedNote: 'Both emit generation_started on entry. When a generation is already running they warn on the console and do nothing. With no model loaded they emit generation_error.',
+          isGeneratingDesc: 'True while an async or streaming generation is running. It is atomic: safe to read from any thread.',
+          getProgressDesc: 'Progress from 0.0 to 1.0, computed as emitted tokens over max_tokens. Returns 0.0 when not generating.',
+          getProgressNote: 'It is progress against the ceiling, not against the real answer: if the model stops before max_tokens, it never reaches 1.0.',
+          cancelDesc: 'Requests aborting the running generation. Does nothing when there is none.',
+          cancelWarn: 'Waits for the worker to finish',
+          cancelWarnText: 'This call blocks until the task actually stops. That is what guarantees no thread is left running, but it means cancelling from the main thread costs a short frame.',
+          propsTitle: 'Properties',
+          propsIntro: 'Exposed as object properties, with setter and getter. They can be assigned directly.',
+          propsNote: 'frequency_penalty, presence_penalty and repeat_last_n exist only as methods (set_/get_), not as properties: they must be called, not assigned.',
+          signalsTitle: 'Signals',
+          sigStarted: 'Emitted when an async or streaming generation starts.',
+          sigToken: 'A freshly generated token, only in generate_streaming. Arrives on the main thread.',
+          sigCompleted: 'Full response, when an async or streaming generation finishes.',
+          sigError: 'Something failed: no model loaded, prompt longer than the context, or a decoding error.',
+          sigProgress: 'Progress from 0.0 to 1.0 during generation.',
+          sigCancelled: 'Emitted when cancel_generation stops the generation.',
+          sigTimeout: 'The time configured with set_timeout ran out and generation was cut.',
+          tblType: 'Type', tblKey: 'Key', tblSignal: 'Signal', tblProp: 'Property', tblRange: 'Range'
         }
       },
       init() {
@@ -487,6 +557,269 @@ llama.load_model(<span class="text-ai-orange">"res://models/model.gguf"</span>)<
         </table>
       </div>
 
+      <h3 class="text-lg font-bold text-white mb-4" data-i18n="sampling">Parametros de Sampling</h3>
+      <div class="overflow-x-auto mb-8">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border-default">
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium">Retorno</th>
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium">Metodo</th>
+            </tr>
+          </thead>
+          <tbody class="text-sm">
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_temperature(temperature: float)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_temperature() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_top_p(top_p: float)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_top_p() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_top_k(top_k: int)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_top_k() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_min_p(min_p: float)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_min_p() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_max_tokens(max_tokens: int)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_max_tokens() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_repeat_penalty(penalty: float)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_repeat_penalty() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_repeat_last_n(n: int)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_repeat_last_n() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_frequency_penalty(penalty: float)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_frequency_penalty() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_presence_penalty(penalty: float)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_presence_penalty() const</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_seed(seed: int)</td>
+            </tr>
+            <tr>
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_seed() const</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3 class="text-lg font-bold text-white mb-4" data-i18n="stopSeq">Stop Sequences</h3>
+      <div class="overflow-x-auto mb-8">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border-default">
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium">Retorno</th>
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium">Metodo</th>
+            </tr>
+          </thead>
+          <tbody class="text-sm">
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_stop_sequences(sequences: PackedStringArray)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">PackedStringArray</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_stop_sequences() const</td>
+            </tr>
+            <tr>
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">clear_stop_sequences()</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3 class="text-lg font-bold text-white mb-4" data-i18n="timeout">Timeout</h3>
+      <div class="overflow-x-auto mb-8">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border-default">
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium">Retorno</th>
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium">Metodo</th>
+            </tr>
+          </thead>
+          <tbody class="text-sm">
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">void</td>
+              <td class="py-3 px-4 font-mono text-gray-300">set_timeout(timeout_ms: int)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">get_timeout() const</td>
+            </tr>
+            <tr>
+              <td class="py-3 px-4 font-mono text-ai-purple">bool</td>
+              <td class="py-3 px-4 font-mono text-gray-300">has_generation_timed_out() const</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <hr class="border-border-default mb-12">
+
+      <h2 class="text-2xl font-bold text-ai-cyan mb-6 flex items-center gap-2">
+        <span class="text-ai-purple">//</span>
+        <span data-i18n="propsTitle">Propiedades</span>
+      </h2>
+
+      <p class="text-gray-400 mb-4" data-i18n="propsIntro">Expuestas como propiedades del objeto, con setter y getter. Se pueden asignar directo.</p>
+
+      <div class="overflow-x-auto mb-4">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border-default">
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium" data-i18n="tblType">Tipo</th>
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium" data-i18n="tblProp">Propiedad</th>
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium" data-i18n="tblRange">Rango</th>
+            </tr>
+          </thead>
+          <tbody class="text-sm">
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">temperature</td>
+              <td class="py-3 px-4 font-mono text-gray-400">0.0 - 2.0</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">top_p</td>
+              <td class="py-3 px-4 font-mono text-gray-400">0.0 - 1.0</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">top_k</td>
+              <td class="py-3 px-4 font-mono text-gray-400">0 - 100</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">max_tokens</td>
+              <td class="py-3 px-4 font-mono text-gray-400">1 - 4096</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">repeat_penalty</td>
+              <td class="py-3 px-4 font-mono text-gray-400">1.0 - 2.0</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">float</td>
+              <td class="py-3 px-4 font-mono text-gray-300">min_p</td>
+              <td class="py-3 px-4 font-mono text-gray-400">0.0 - 1.0</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">seed</td>
+              <td class="py-3 px-4 font-mono text-gray-400">—</td>
+            </tr>
+            <tr>
+              <td class="py-3 px-4 font-mono text-ai-purple">int</td>
+              <td class="py-3 px-4 font-mono text-gray-300">timeout</td>
+              <td class="py-3 px-4 font-mono text-gray-400">0 - 300000</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="p-4 rounded-lg border border-warning/30 bg-warning/5 mb-12">
+        <p class="text-gray-300 text-sm" data-i18n="propsNote">frequency_penalty, presence_penalty y repeat_last_n existen sólo como métodos (set_/get_), no como propiedades: hay que llamarlos, no asignarlos.</p>
+      </div>
+
+      <hr class="border-border-default mb-12">
+
+      <h2 class="text-2xl font-bold text-ai-cyan mb-6 flex items-center gap-2">
+        <span class="text-ai-purple">//</span>
+        <span data-i18n="signalsTitle">Señales</span>
+      </h2>
+
+      <div class="overflow-x-auto mb-12">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b border-border-default">
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium" data-i18n="tblSignal">Señal</th>
+              <th class="text-left py-3 px-4 text-ai-cyan font-medium" data-i18n="pTableDesc">Descripción</th>
+            </tr>
+          </thead>
+          <tbody class="text-sm">
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-cyan whitespace-nowrap">generation_started()</td>
+              <td class="py-3 px-4 text-gray-300" data-i18n="sigStarted">Emitida al arrancar una generación async o streaming.</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-cyan whitespace-nowrap">token_generated(token: String)</td>
+              <td class="py-3 px-4 text-gray-300" data-i18n="sigToken">Un token recién generado, sólo en generate_streaming. Llega en el hilo principal.</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-cyan whitespace-nowrap">generation_completed(response: String)</td>
+              <td class="py-3 px-4 text-gray-300" data-i18n="sigCompleted">Respuesta completa, al terminar una generación async o streaming.</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-cyan whitespace-nowrap">generation_progress(progress: float)</td>
+              <td class="py-3 px-4 text-gray-300" data-i18n="sigProgress">Progreso de 0.0 a 1.0 durante la generación.</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-cyan whitespace-nowrap">generation_error(error: String)</td>
+              <td class="py-3 px-4 text-gray-300" data-i18n="sigError">Algo falló: sin modelo cargado, prompt más largo que el contexto, o error de decodificación.</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-3 px-4 font-mono text-ai-cyan whitespace-nowrap">generation_cancelled()</td>
+              <td class="py-3 px-4 text-gray-300" data-i18n="sigCancelled">Emitida cuando cancel_generation detiene la generación.</td>
+            </tr>
+            <tr>
+              <td class="py-3 px-4 font-mono text-ai-cyan whitespace-nowrap">generation_timeout()</td>
+              <td class="py-3 px-4 text-gray-300" data-i18n="sigTimeout">El tiempo configurado con set_timeout se agotó y la generación se cortó.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <hr class="border-border-default mb-12">
+
       <h3 class="text-lg font-bold text-white mb-4" data-i18n="methodDesc">Descripciones de Metodos</h3>
 
       <div id="load_model" class="mb-12">
@@ -586,6 +919,188 @@ llama.load_model(<span class="text-ai-orange">"res://models/model.gguf"</span>)<
         </div>
       </div>
 
+      <div id="unload_model" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">unload_model</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> unload_model()</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="unloadModelDesc">Libera el modelo, el contexto y el sampler. No hace nada si no hay modelo cargado.</p>
+      </div>
+
+      <div id="is_model_loaded" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">is_model_loaded</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">bool</span> is_model_loaded() const</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="isModelLoadedDesc">Devuelve true sólo cuando el modelo Y el contexto existen. Un handle a medio construir da false.</p>
+      </div>
+
+      <div id="get_model_info" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">get_model_info</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">Dictionary</span> get_model_info() const</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="getModelInfoDesc">Metadatos del modelo cargado. Devuelve un Dictionary vacío si no hay ninguno.</p>
+        <h5 class="text-sm font-bold text-gray-300 mb-2 uppercase tracking-wider" data-i18n="getModelInfoKeys">Claves devueltas</h5>
+        <div class="overflow-x-auto mb-4">
+          <table class="w-full border-collapse">
+            <thead>
+              <tr class="border-b border-border-default">
+                <th class="text-left py-2 px-4 text-ai-cyan text-sm" data-i18n="tblKey">Clave</th>
+                <th class="text-left py-2 px-4 text-ai-cyan text-sm" data-i18n="pTableType">Tipo</th>
+              </tr>
+            </thead>
+            <tbody class="text-sm">
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">description</td>
+                <td class="py-2 px-4 font-mono text-gray-400">String</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">path</td>
+                <td class="py-2 px-4 font-mono text-gray-400">String</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">size_bytes</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_params</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_ctx_train</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_embd</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_layer</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_head</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_ctx</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_batch</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">vocab_size</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">vocab_type</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">bos_token</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">eos_token</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">has_encoder</td>
+                <td class="py-2 px-4 font-mono text-gray-400">bool</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">has_decoder</td>
+                <td class="py-2 px-4 font-mono text-gray-400">bool</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">is_recurrent</td>
+                <td class="py-2 px-4 font-mono text-gray-400">bool</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">rope_type</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">chat_template</td>
+                <td class="py-2 px-4 font-mono text-gray-400">String</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">n_gpu_layers</td>
+                <td class="py-2 px-4 font-mono text-gray-400">int</td>
+              </tr>
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">gpu_backend_name</td>
+                <td class="py-2 px-4 font-mono text-gray-400">String</td>
+              </tr>
+              <tr>
+                <td class="py-2 px-4 font-mono text-ai-purple">gpu_backend_desc</td>
+                <td class="py-2 px-4 font-mono text-gray-400">String</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="p-4 rounded-lg border border-ai-cyan/30 bg-ai-cyan/5 mb-4">
+          <p class="text-gray-300 text-sm" data-i18n="getModelInfoNote">bos_token y eos_token sólo aparecen si el modelo los define. chat_template sólo si el GGUF trae plantilla embebida.</p>
+        </div>
+      </div>
+
+      <div id="get_model_path" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">get_model_path</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">String</span> get_model_path() const</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="getModelPathDesc">Ruta del modelo cargado, tal cual se pasó a load_model. Cadena vacía si no hay ninguno.</p>
+      </div>
+
+      <div id="get_system_info" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">get_system_info</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">String</span> get_system_info() const</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="getSystemInfoDesc">Cadena de llama.cpp con las capacidades de CPU detectadas (AVX, NEON, etc.). Útil para reportes de bug.</p>
+      </div>
+
+      <div id="get_chat_template" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">get_chat_template</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">String</span> get_chat_template() const</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="getChatTemplateDesc">Plantilla de chat embebida en el GGUF, en formato Jinja. Cadena vacía si el modelo no trae ninguna o no hay modelo cargado.</p>
+      </div>
+
+      <div id="apply_chat_template" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">apply_chat_template</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">String</span> apply_chat_template(messages: <span class="text-ai-cyan">Array</span>, add_generation_prompt: <span class="text-ai-cyan">bool</span> = <span class="text-ai-purple">true</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="applyChatTemplateDesc">Aplica la plantilla del modelo a una lista de mensajes y devuelve el prompt final.</p>
+        <h5 class="text-sm font-bold text-gray-300 mb-2 uppercase tracking-wider" data-i18n="paramsTitle">Parámetros</h5>
+        <div class="overflow-x-auto mb-4">
+          <table class="w-full border-collapse">
+            <thead>
+              <tr class="border-b border-border-default">
+                <th class="text-left py-2 px-4 text-ai-cyan text-sm" data-i18n="pTableParam">Parámetro</th>
+                <th class="text-left py-2 px-4 text-ai-cyan text-sm" data-i18n="pTableType">Tipo</th>
+                <th class="text-left py-2 px-4 text-ai-cyan text-sm" data-i18n="pTableDesc">Descripción</th>
+              </tr>
+            </thead>
+            <tbody class="text-sm">
+              <tr class="border-b border-border-default/50">
+                <td class="py-2 px-4 font-mono text-ai-purple">messages</td>
+                <td class="py-2 px-4 font-mono text-gray-400">Array</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="paramMessagesDesc">Array de Dictionary con las claves role y content. Los que no tengan ambas se descartan con un warning.</td>
+              </tr>
+              <tr>
+                <td class="py-2 px-4 font-mono text-ai-purple">add_generation_prompt</td>
+                <td class="py-2 px-4 font-mono text-gray-400">bool</td>
+                <td class="py-2 px-4 text-gray-300" data-i18n="paramAddGenDesc">Añade el encabezado que le indica al modelo que empiece a responder</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">var</span> prompt := llama.<span class="text-ai-cyan">apply_chat_template</span>([
+    {<span class="text-ai-green">"role"</span>: <span class="text-ai-green">"system"</span>, <span class="text-ai-green">"content"</span>: <span class="text-ai-green">"Sos un herrero gruñón."</span>},
+    {<span class="text-ai-green">"role"</span>: <span class="text-ai-green">"user"</span>, <span class="text-ai-green">"content"</span>: <span class="text-ai-green">"¿Cuánto cuesta la espada?"</span>},
+])</code></pre>
+      </div>
+
       <!-- count_tokens -->
       <div id="count_tokens" class="mb-12">
         <h4 class="text-xl font-bold text-gray-200 mb-4">count_tokens</h4>
@@ -626,6 +1141,66 @@ llama.<span class="text-ai-cyan">load_model</span>(<span class="text-ai-green">"
           <p class="text-gray-300 text-sm" data-i18n="vocabOnlyWarn">Un handle vocab_only sirve para tokenizar, NO para
             generar. Además deja n_ctx_train sin poblar, así que el tamaño de contexto del archivo no se puede leer por
             esta vía.</p>
+        </div>
+      </div>
+
+      <div id="generate" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">generate</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">String</span> generate(prompt: <span class="text-ai-cyan">String</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="generateDesc">Genera la respuesta completa y la devuelve. Cadena vacía ante cualquier error.</p>
+        <div class="p-4 rounded-lg border border-error/30 bg-error/5 mb-4">
+          <p class="text-error font-bold text-sm mb-1" data-i18n="generateWarn">Bloquea el hilo que la llama</p>
+          <p class="text-gray-300 text-sm" data-i18n="generateWarnText">Llamada desde el hilo principal, congela el juego hasta el último token. Para gameplay usá generate_async o generate_streaming.</p>
+        </div>
+      </div>
+
+      <div id="generate_async" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">generate_async</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> generate_async(prompt: <span class="text-ai-cyan">String</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="generateAsyncDesc">Genera en el WorkerThreadPool y entrega el texto por generation_completed. No devuelve nada.</p>
+      </div>
+
+      <div id="generate_streaming" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">generate_streaming</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> generate_streaming(prompt: <span class="text-ai-cyan">String</span>)</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="generateStreamingDesc">Igual que generate_async, pero además emite token_generated por cada token a medida que sale.</p>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code>llama.token_generated.<span class="text-ai-cyan">connect</span>(<span class="text-ai-purple">func</span>(token): label.text += token)
+llama.generation_completed.<span class="text-ai-cyan">connect</span>(<span class="text-ai-purple">func</span>(full): <span class="text-ai-cyan">print</span>(full))
+llama.<span class="text-ai-cyan">generate_streaming</span>(<span class="text-ai-green">"Hola, ¿qué vendés?"</span>)</code></pre>
+        <div class="p-4 rounded-lg border border-ai-cyan/30 bg-ai-cyan/5 mb-4">
+          <p class="text-gray-300 text-sm" data-i18n="genSharedNote">Ambas emiten generation_started al arrancar. Si ya hay una generación en curso, avisan por consola y no hacen nada. Sin modelo cargado emiten generation_error.</p>
+        </div>
+      </div>
+
+      <div id="is_generating" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">is_generating</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">bool</span> is_generating() const</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="isGeneratingDesc">True mientras hay una generación async o streaming en curso. Es atómico: se puede consultar desde cualquier hilo.</p>
+      </div>
+
+      <div id="get_generation_progress" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">get_generation_progress</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">float</span> get_generation_progress() const</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="getProgressDesc">Progreso de 0.0 a 1.0, calculado como tokens emitidos sobre max_tokens. Devuelve 0.0 si no se está generando.</p>
+        <div class="p-4 rounded-lg border border-warning/30 bg-warning/5 mb-4">
+          <p class="text-gray-300 text-sm" data-i18n="getProgressNote">Es un progreso contra el techo, no contra la respuesta real: si el modelo termina antes de max_tokens, nunca llega a 1.0.</p>
+        </div>
+      </div>
+
+      <div id="cancel_generation" class="mb-12">
+        <h4 class="text-xl font-bold text-gray-200 mb-4">cancel_generation</h4>
+        <pre
+          class="p-4 rounded-lg bg-black/40 border border-border-default font-mono text-sm text-gray-300 mb-4 overflow-x-auto"><code><span class="text-ai-purple">void</span> cancel_generation()</code></pre>
+        <p class="text-gray-400 mb-4" data-i18n="cancelDesc">Pide abortar la generación en curso. No hace nada si no hay ninguna.</p>
+        <div class="p-4 rounded-lg border border-warning/30 bg-warning/5 mb-4">
+          <p class="text-warning font-bold text-sm mb-1" data-i18n="cancelWarn">Espera a que el worker termine</p>
+          <p class="text-gray-300 text-sm" data-i18n="cancelWarnText">Esta llamada bloquea hasta que la tarea se detiene de verdad. Es lo que garantiza que no queden hilos sueltos, pero significa que cancelar desde el hilo principal cuesta un frame corto.</p>
         </div>
       </div>
 

--- a/docs/API/resources.html
+++ b/docs/API/resources.html
@@ -25,9 +25,9 @@
           pageSubtitle: 'Los Resources son objetos de datos serializables de Godot que almacenan configuración reutilizable. OhMyDialogSystem usa Resources para definir personajes, mundos, grafos de diálogo y más.',
           tipTitle: 'Tip',
           tipContent: 'Los Resources se guardan como archivos .tres y se pueden crear desde el menú New Resource en Godot, o desde el FileSystem haciendo click derecho.',
-          propGroup: 'Grupo', propProp: 'Propiedad', propType: 'Tipo', propDesc: 'Descripción', propDefault: 'Default',
+          propGroup: 'Grupo', propProp: 'Propiedad', propType: 'Tipo', propDesc: 'Descripción',
           tableSignal: 'Signal', tableParams: 'Parámetros',
-          enumTitle: 'Enum', methodsTitle: 'Métodos', exampleTitle: 'Ejemplo de Uso',
+          enumTitle: 'Enum', methodsTitle: 'Métodos',
           backToHome: 'Volver a API Reference',
           // DialogueNodeData
           dndTitle: 'DialogueNodeData',
@@ -72,6 +72,7 @@
           ciEx: 'Líneas de ejemplo que demuestran la voz',
           ciMToPrompt: 'Genera el system prompt para el LLM. Este es el método principal que convierte los datos del personaje en instrucciones para la IA.',
           ciMIsValid: 'Retorna true si tiene character_id y character_name.',
+          ciMEstTok: 'Aproxima el costo del prompt a razón de ~4 caracteres por token. Es una estimación: para el número exacto, el editor usa el tokenizador del propio modelo vía TokenCounter.',
           // WorldContext
           wcTitle: 'WorldContext',
           wcDesc: 'Define el contexto del mundo para la generación de diálogos. Incluye setting, lore, eventos actuales y estado dinámico que puede cambiar durante el juego.',
@@ -103,6 +104,8 @@
           dgDescProp: 'Descripción del diálogo',
           dgChar: 'Personaje por defecto para respuestas IA',
           dgWorld: 'Contexto del mundo',
+          dgPreset: 'Preset de sampling aplicado al arrancar el diálogo',
+          dgModelPath: 'Modelo .gguf fijado a este grafo. start_dialogue lo carga solo, y el editor lo usa para contar tokens',
           dgNodes: 'node_id → DialogueNodeData',
           dgConn: 'Conexiones entre nodos',
           dgStart: 'ID del nodo de inicio',
@@ -139,6 +142,18 @@
           aiFreqPen: 'Penaliza por frecuencia (estilo OpenAI)',
           aiPresPen: 'Penaliza si apareció (estilo OpenAI)',
           aiCtx: 'Tamaño máximo de contexto en tokens',
+          aiSeed: 'Semilla del generador. -1 = aleatoria en cada respuesta',
+          aiMiro: 'Modo Mirostat: 0 apagado, 1 v1, 2 v2. Sustituye a top_k/top_p cuando está activo',
+          aiSrcTpl: 'Plantilla Jinja copiada del GGUF, si el modelo trae una',
+          aiTplFmt: 'Formato detectado de la plantilla (chatml, llama3, etc.)',
+          aiArch: 'Arquitectura leída del GGUF (qwen2, llama, etc.)',
+          aiBos: 'ID del token de inicio de secuencia. -1 si el modelo no lo define',
+          aiEos: 'ID del token de fin de secuencia. -1 si el modelo no lo define',
+          aiRecCtx: 'n_ctx_train del modelo: el contexto con el que fue entrenado',
+          aiDerStop: 'Stop sequences deducidas del formato de plantilla',
+          aiMCons: 'Crea preset consistente (baja temperatura).',
+          aiMTech: 'Crea preset técnico (respuestas precisas).',
+          aiMGet: 'Devuelve el preset correspondiente a un PresetType.',
           aiRes: 'Tokens reservados para respuesta',
           aiSeed: 'Semilla (-1 = aleatorio)',
           aiMiro: 'Modo Mirostat (0=off, 1=v1, 2=v2)',
@@ -175,6 +190,23 @@
           mcGpu: 'Capas GPU (-1 = todas, 0 = CPU)',
           mcBatch: 'Batch size para prompt (512)',
           mcArch: 'Arquitectura (llama, qwen2, phi...)',
+          mcMetaUrl: 'Endpoint con los metadatos del GGUF, para leerlos sin descargar el archivo',
+          mcCustom: 'El usuario lo añadió a mano, no viene del registro',
+          mcExport: 'Empaquetar este modelo en la build exportada',
+          mcDefTopP: 'top_p por defecto (0.95)',
+          mcDefTopK: 'top_k por defecto (40)',
+          mcDefMax: 'Máximo de tokens por respuesta (256)',
+          mcDefRep: 'Penalización por repetición (1.1)',
+          mcBatch: 'Tamaño de lote para el prompt (512)',
+          mcBos: 'ID del token de inicio. -1 si no está definido',
+          mcEos: 'ID del token de fin. -1 si no está definido',
+          mcPreset: 'Preset derivado de estos metadatos',
+          mcMLoad: 'Arma el Dictionary para load_model con n_ctx, n_gpu_layers y n_batch.',
+          mcMApply: 'Escribe los seis default_* sobre las propiedades de sampling de la instancia.',
+          mcMFile: 'Nombre del archivo, sacado de download_url o construido como id.gguf.',
+          mcMHas: 'True si ya se leyeron los metadatos del GGUF.',
+          mcMPop: 'Rellena arquitectura, plantilla y tokens especiales desde los metadatos del GGUF.',
+          mcMPreset: 'Construye un AIPreset a partir de estos metadatos.',
           mcChatT: 'Chat template Jinja2 del modelo',
           mcFormat: 'Formato detectado (chatml, llama3...)',
           mcBos: 'ID del token BOS (-1 si no existe)',
@@ -197,9 +229,9 @@
           pageSubtitle: 'Resources are serializable Godot data objects that store reusable configuration. OhMyDialogSystem uses Resources to define characters, worlds, dialogue graphs, and more.',
           tipTitle: 'Tip',
           tipContent: 'Resources are saved as .tres files and can be created from the New Resource menu in Godot, or by right-clicking in the FileSystem.',
-          propGroup: 'Group', propProp: 'Property', propType: 'Type', propDesc: 'Description', propDefault: 'Default',
+          propGroup: 'Group', propProp: 'Property', propType: 'Type', propDesc: 'Description',
           tableSignal: 'Signal', tableParams: 'Parameters',
-          enumTitle: 'Enum', methodsTitle: 'Methods', exampleTitle: 'Usage Example',
+          enumTitle: 'Enum', methodsTitle: 'Methods',
           backToHome: 'Back to API Reference',
           // DialogueNodeData (EN)
           dndTitle: 'DialogueNodeData',
@@ -244,6 +276,7 @@
           ciEx: 'Example lines demonstrating voice',
           ciMToPrompt: 'Generates system prompt for LLM. Main method converting character data into AI instructions.',
           ciMIsValid: 'Returns true if has character_id and character_name.',
+          ciMEstTok: 'Approximates the prompt cost at ~4 characters per token. It is an estimate: for the exact number the editor uses the model own tokenizer through TokenCounter.',
           // WorldContext (EN)
           wcTitle: 'WorldContext',
           wcDesc: 'Defines world context for dialogue generation. Includes setting, lore, current events, and dynamic state changing during game.',
@@ -275,6 +308,8 @@
           dgDescProp: 'Dialogue description',
           dgChar: 'Default character for AI responses',
           dgWorld: 'World context',
+          dgPreset: 'Sampling preset applied when the dialogue starts',
+          dgModelPath: 'The .gguf model pinned to this graph. start_dialogue loads it on its own, and the editor uses it to count tokens',
           dgNodes: 'node_id → DialogueNodeData',
           dgConn: 'Connections between nodes',
           dgStart: 'Start node ID',
@@ -311,6 +346,18 @@
           aiFreqPen: 'Frequency penalty (OpenAI style)',
           aiPresPen: 'Presence penalty (OpenAI style)',
           aiCtx: 'Maximum context size in tokens',
+          aiSeed: 'Generator seed. -1 = random on every response',
+          aiMiro: 'Mirostat mode: 0 off, 1 v1, 2 v2. It replaces top_k/top_p while active',
+          aiSrcTpl: 'Jinja template copied from the GGUF, when the model ships one',
+          aiTplFmt: 'Detected template format (chatml, llama3, etc.)',
+          aiArch: 'Architecture read from the GGUF (qwen2, llama, etc.)',
+          aiBos: 'Beginning-of-sequence token ID. -1 when the model does not define it',
+          aiEos: 'End-of-sequence token ID. -1 when the model does not define it',
+          aiRecCtx: 'The model n_ctx_train: the context it was trained with',
+          aiDerStop: 'Stop sequences derived from the template format',
+          aiMCons: 'Creates a consistent preset (low temperature).',
+          aiMTech: 'Creates a technical preset (precise answers).',
+          aiMGet: 'Returns the preset matching a PresetType.',
           aiRes: 'Reserved tokens for response',
           aiSeed: 'Seed (-1 = random)',
           aiMiro: 'Mirostat mode (0=off, 1=v1, 2=v2)',
@@ -347,6 +394,23 @@
           mcGpu: 'GPU layers (-1 = all, 0 = CPU)',
           mcBatch: 'Prompt batch size (512)',
           mcArch: 'Architecture (llama, qwen2, phi...)',
+          mcMetaUrl: 'Endpoint with the GGUF metadata, to read it without downloading the file',
+          mcCustom: 'The user added it by hand, it does not come from the registry',
+          mcExport: 'Pack this model into the exported build',
+          mcDefTopP: 'Default top_p (0.95)',
+          mcDefTopK: 'Default top_k (40)',
+          mcDefMax: 'Max tokens per response (256)',
+          mcDefRep: 'Repetition penalty (1.1)',
+          mcBatch: 'Prompt batch size (512)',
+          mcBos: 'Beginning token ID. -1 when undefined',
+          mcEos: 'End token ID. -1 when undefined',
+          mcPreset: 'Preset derived from this metadata',
+          mcMLoad: 'Builds the load_model Dictionary with n_ctx, n_gpu_layers and n_batch.',
+          mcMApply: 'Writes the six default_* onto the sampling properties of the instance.',
+          mcMFile: 'File name, taken from download_url or built as id.gguf.',
+          mcMHas: 'True when the GGUF metadata has already been read.',
+          mcMPop: 'Fills architecture, template and special tokens from the GGUF metadata.',
+          mcMPreset: 'Builds an AIPreset from this metadata.',
           mcChatT: 'Model Jinja2 chat template',
           mcFormat: 'Detected format (chatml, llama3...)',
           mcBos: 'BOS token ID (-1 if none)',
@@ -801,6 +865,22 @@
         </table>
       </div>
 
+      <h3 class="text-lg font-bold text-white mb-4" data-i18n="methodsTitle">Métodos</h3>
+      <div class="grid grid-cols-1 gap-4 mb-8">
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func to_system_prompt() -> String</div>
+          <p class="text-gray-400 text-sm" data-i18n="ciMToPrompt">Genera el system prompt para el LLM. Este es el método principal que convierte los datos del personaje en instrucciones para la IA.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func is_valid() -> bool</div>
+          <p class="text-gray-400 text-sm" data-i18n="ciMIsValid">Retorna true si tiene character_id y character_name.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func estimate_tokens() -> int</div>
+          <p class="text-gray-400 text-sm" data-i18n="ciMEstTok">Aproxima el costo del prompt a razón de ~4 caracteres por token. Es una estimación: para el número exacto, el editor usa el tokenizador del propio modelo vía TokenCounter.</p>
+        </div>
+      </div>
+
       <hr class="border-border-default mb-12">
 
       <!-- ==================== WorldContext ==================== -->
@@ -979,7 +1059,7 @@
               <td class="py-2 px-4 text-gray-300" data-i18n="dgDescProp">Descripción del diálogo</td>
             </tr>
             <tr class="border-b border-border-default/50">
-              <td rowspan="2" class="py-2 px-4 font-bold text-gray-500">Context</td>
+              <td rowspan="4" class="py-2 px-4 font-bold text-gray-500">Context</td>
               <td class="py-2 px-4 font-mono text-ai-purple">default_character</td>
               <td class="py-2 px-4 font-mono text-gray-400">CharacterIdentity</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="dgChar">Personaje por defecto para respuestas IA</td>
@@ -988,6 +1068,16 @@
               <td class="py-2 px-4 font-mono text-ai-purple">world_context</td>
               <td class="py-2 px-4 font-mono text-gray-400">WorldContext</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="dgWorld">Contexto del mundo</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">ai_preset</td>
+              <td class="py-2 px-4 font-mono text-gray-400">AIPreset</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="dgPreset">Preset de sampling aplicado al arrancar el diálogo</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-green">model_path</td>
+              <td class="py-2 px-4 font-mono text-gray-400">String</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="dgModelPath">Modelo .gguf fijado a este grafo. start_dialogue lo carga solo, y el editor lo usa para contar tokens</td>
             </tr>
             <tr class="border-b border-border-default/50">
               <td rowspan="3" class="py-2 px-4 font-bold text-gray-500">Graph Data</td>
@@ -1085,6 +1175,22 @@
           <p class="text-gray-400 text-sm" data-i18n="dgMValidate">Valida la estructura del grafo. Retorna array de
             errores.</p>
         </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func get_node(node_id: String) -> DialogueNodeData</div>
+          <p class="text-gray-400 text-sm" data-i18n="dgMGetNode">Obtiene un nodo por su ID.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func get_start_node() -> DialogueNodeData</div>
+          <p class="text-gray-400 text-sm" data-i18n="dgMGetStart">Obtiene el nodo de inicio del grafo.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func disconnect_nodes(from_node: String, from_slot: int, to_node: String, to_slot: int = 0) -> void</div>
+          <p class="text-gray-400 text-sm" data-i18n="dgMDisconn">Elimina una conexión específica.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func get_next_nodes(node_id: String, slot: int = 0) -> Array[DialogueNodeData]</div>
+          <p class="text-gray-400 text-sm" data-i18n="dgMNext">Obtiene los nodos siguientes desde un slot de salida.</p>
+        </div>
       </div>
 
       <hr class="border-border-default mb-12">
@@ -1170,10 +1276,60 @@
               <td class="py-2 px-4 font-mono text-ai-purple">presence_penalty</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="aiPresPen">Penaliza si apareció (estilo OpenAI)</td>
             </tr>
-            <tr>
-              <td class="py-2 px-4 font-bold text-gray-500">Context</td>
+            <tr class="border-b border-border-default/50">
+              <td rowspan="2" class="py-2 px-4 font-bold text-gray-500">Context</td>
               <td class="py-2 px-4 font-mono text-ai-purple">context_size</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="aiCtx">Tamaño máximo de contexto en tokens</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">response_reserve</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiRes">Tokens reservados para la respuesta: el prompt no puede pasar de context_size menos esto</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td rowspan="4" class="py-2 px-4 font-bold text-gray-500">Advanced</td>
+              <td class="py-2 px-4 font-mono text-ai-purple">seed</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiSeed">Semilla del generador. -1 = aleatoria en cada respuesta</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">mirostat</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiMiro">Modo Mirostat: 0 apagado, 1 v1, 2 v2. Sustituye a top_k/top_p cuando está activo</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">mirostat_tau</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiMTau">Entropía objetivo de Mirostat</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">mirostat_eta</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiMEta">Tasa de aprendizaje de Mirostat</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td rowspan="7" class="py-2 px-4 font-bold text-gray-500">Model Metadata</td>
+              <td class="py-2 px-4 font-mono text-ai-purple">source_chat_template</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiSrcTpl">Plantilla Jinja copiada del GGUF, si el modelo trae una</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">chat_template_format</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiTplFmt">Formato detectado de la plantilla (chatml, llama3, etc.)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">model_architecture</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiArch">Arquitectura leída del GGUF (qwen2, llama, etc.)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">bos_token_id</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiBos">ID del token de inicio de secuencia. -1 si el modelo no lo define</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">eos_token_id</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiEos">ID del token de fin de secuencia. -1 si el modelo no lo define</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">recommended_context_length</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiRecCtx">n_ctx_train del modelo: el contexto con el que fue entrenado</td>
+            </tr>
+            <tr>
+              <td class="py-2 px-4 font-mono text-ai-purple">derived_stop_sequences</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="aiDerStop">Stop sequences deducidas del formato de plantilla</td>
             </tr>
           </tbody>
         </table>
@@ -1202,6 +1358,26 @@
             func create_roleplay() -> AIPreset</div>
           <p class="text-gray-400 text-sm" data-i18n="aiMRole">Crea preset roleplay.</p>
         </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">static func create_consistent() -> AIPreset</div>
+          <p class="text-gray-400 text-sm" data-i18n="aiMCons">Crea preset consistente (baja temperatura).</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">static func create_technical() -> AIPreset</div>
+          <p class="text-gray-400 text-sm" data-i18n="aiMTech">Crea preset técnico (respuestas precisas).</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">static func get_preset(type: PresetType) -> AIPreset</div>
+          <p class="text-gray-400 text-sm" data-i18n="aiMGet">Devuelve el preset correspondiente a un PresetType.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">static func create_from_gguf_metadata(metadata: Dictionary, base_type: PresetType = BALANCED, model_name: String = "") -> AIPreset</div>
+          <p class="text-gray-400 text-sm" data-i18n="aiMFromGGUF">Construye un preset a partir de los metadatos de un GGUF: plantilla, arquitectura, tokens especiales y stop sequences derivadas.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func get_summary() -> String</div>
+          <p class="text-gray-400 text-sm" data-i18n="aiMSum">Retorna resumen del preset para debug.</p>
+        </div>
       </div>
 
       <hr class="border-border-default mb-12">
@@ -1228,7 +1404,7 @@
           </thead>
           <tbody class="text-sm">
             <tr class="border-b border-border-default/50">
-              <td rowspan="5" class="py-2 px-4 font-bold text-gray-500">Model Info</td>
+              <td rowspan="10" class="py-2 px-4 font-bold text-gray-500">Model Info</td>
               <td class="py-2 px-4 font-mono text-ai-purple">id</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="mcId">ID único del modelo</td>
             </tr>
@@ -1237,23 +1413,64 @@
               <td class="py-2 px-4 text-gray-300" data-i18n="mcName">Nombre legible</td>
             </tr>
             <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">description</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcMDesc">Para qué sirve este modelo, mostrado en el Model Manager</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
               <td class="py-2 px-4 font-mono text-ai-purple">model_path</td>
-              <td class="py-2 px-4 text-gray-300" data-i18n="mcPath">Ruta al archivo GGUF</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcPath">Ruta al archivo GGUF. Si está vacía se deduce de get_filename()</td>
             </tr>
             <tr class="border-b border-border-default/50">
               <td class="py-2 px-4 font-mono text-ai-purple">download_url</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="mcUrl">URL de HuggingFace para descarga</td>
             </tr>
             <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">documentation_url</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcDoc">Ficha del modelo en HuggingFace</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">file_metadata_url</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcMetaUrl">Endpoint con los metadatos del GGUF, para leerlos sin descargar el archivo</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
               <td class="py-2 px-4 font-mono text-ai-purple">size_mb</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="mcSize">Tamaño estimado en MB</td>
             </tr>
             <tr class="border-b border-border-default/50">
-              <td rowspan="3" class="py-2 px-4 font-bold text-gray-500">Defaults</td>
+              <td class="py-2 px-4 font-mono text-ai-purple">is_custom</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcCustom">El usuario lo añadió a mano, no viene del registro</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">include_in_export</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcExport">Empaquetar este modelo en la build exportada</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td rowspan="6" class="py-2 px-4 font-bold text-gray-500">Default Sampling</td>
               <td class="py-2 px-4 font-mono text-ai-purple">default_temperature</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="mcDefTemp">Temperatura por defecto (0.7)</td>
             </tr>
             <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">default_top_p</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcDefTopP">top_p por defecto (0.95)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">default_top_k</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcDefTopK">top_k por defecto (40)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">default_max_tokens</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcDefMax">Máximo de tokens por respuesta (256)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">default_repeat_penalty</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcDefRep">Penalización por repetición (1.1)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">default_min_p</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcDefMin">min_p por defecto (0.05)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td rowspan="3" class="py-2 px-4 font-bold text-gray-500">Context</td>
               <td class="py-2 px-4 font-mono text-ai-purple">n_ctx</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="mcCtx">Tamaño de contexto en tokens (2048)</td>
             </tr>
@@ -1261,13 +1478,73 @@
               <td class="py-2 px-4 font-mono text-ai-purple">n_gpu_layers</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="mcGpu">Capas GPU (-1 = todas)</td>
             </tr>
-            <tr>
-              <td class="py-2 px-4 font-bold text-gray-500">Metadata</td>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">n_batch</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcBatch">Tamaño de lote para el prompt (512)</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td rowspan="6" class="py-2 px-4 font-bold text-gray-500">GGUF Metadata</td>
               <td class="py-2 px-4 font-mono text-ai-purple">architecture</td>
               <td class="py-2 px-4 text-gray-300" data-i18n="mcArch">Arquitectura (llama, qwen2...)</td>
             </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">raw_chat_template</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcChatT">Plantilla Jinja tal cual viene en el GGUF</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">chat_template_format</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcFormat">Formato detectado de la plantilla</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">bos_token_id</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcBos">ID del token de inicio. -1 si no está definido</td>
+            </tr>
+            <tr class="border-b border-border-default/50">
+              <td class="py-2 px-4 font-mono text-ai-purple">eos_token_id</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcEos">ID del token de fin. -1 si no está definido</td>
+            </tr>
+            <tr>
+              <td class="py-2 px-4 font-mono text-ai-purple">ai_preset</td>
+              <td class="py-2 px-4 text-gray-300" data-i18n="mcPreset">Preset derivado de estos metadatos</td>
+            </tr>
           </tbody>
         </table>
+      </div>
+
+      <h3 class="text-lg font-bold text-white mb-4" data-i18n="methodsTitle">Métodos</h3>
+      <div class="grid grid-cols-1 gap-4 mb-8">
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func get_effective_path() -> String</div>
+          <p class="text-gray-400 text-sm" data-i18n="mcmPath">Dónde está el archivo: model_path si tiene valor, si no res://models/ más get_filename().</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func get_load_params() -> Dictionary</div>
+          <p class="text-gray-400 text-sm" data-i18n="mcMLoad">Arma el Dictionary para load_model con n_ctx, n_gpu_layers y n_batch.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func apply_defaults_to(llama: LlamaInterface) -> void</div>
+          <p class="text-gray-400 text-sm" data-i18n="mcMApply">Escribe los seis default_* sobre las propiedades de sampling de la instancia.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func is_downloaded() -> bool</div>
+          <p class="text-gray-400 text-sm" data-i18n="mcMDown">True si el archivo existe en la ruta efectiva.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func get_filename() -> String</div>
+          <p class="text-gray-400 text-sm" data-i18n="mcMFile">Nombre del archivo, sacado de download_url o construido como id.gguf.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func has_metadata() -> bool</div>
+          <p class="text-gray-400 text-sm" data-i18n="mcMHas">True si ya se leyeron los metadatos del GGUF.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func populate_from_metadata(metadata: Dictionary) -> void</div>
+          <p class="text-gray-400 text-sm" data-i18n="mcMPop">Rellena arquitectura, plantilla y tokens especiales desde los metadatos del GGUF.</p>
+        </div>
+        <div>
+          <div class="font-mono text-sm bg-black/40 p-2 rounded border border-border-default mb-2 text-gray-300">func create_ai_preset() -> AIPreset</div>
+          <p class="text-gray-400 text-sm" data-i18n="mcMPreset">Construye un AIPreset a partir de estos metadatos.</p>
+        </div>
       </div>
 
       <hr class="border-border-default mb-12">

--- a/docs/Technical/dialogue-nodes.html
+++ b/docs/Technical/dialogue-nodes.html
@@ -36,6 +36,8 @@
           nodeStart: 'StartNode', subStart: 'Punto de entrada', descStart: 'Marca el inicio del grafo de dialogo. Cada grafo debe tener exactamente un StartNode.',
           nodeEnd: 'EndNode', subEnd: 'Termina dialogo', descEnd: 'Finaliza la ejecucion del grafo. Puede indicar una razon para analytics.',
           nodeAI: 'AIResponseNode', subAI: 'IA genera respuesta', descAI: 'La IA genera texto dinamicamente usando LlamaInterface y el CharacterIdentity del NPC.',
+          lbAICostTitle: 'Costo en tokens en el editor',
+          lbAICostText: 'El nodo muestra lo que cuesta su prompt (CharacterIdentity + WorldContext + plantilla). Si el grafo tiene un modelo asignado, se tokeniza con el vocabulario real de ese modelo sin cargarlo en memoria; si no, se cae a la estimacion de ~4 caracteres por token y el numero se muestra con "~". La barra de uso solo aparece cuando hay un modelo cargado: sin el no hay ventana de contexto contra la cual medir.',
           nodeStatic: 'StaticResponseNode', subStatic: 'Texto pre-escrito', descStatic: 'Muestra texto fijo, sin generacion de IA. Soporta sustitucion de variables.',
           nodeChoice: 'PlayerChoiceNode', subChoice: 'Opciones del jugador', descChoice: 'Presenta opciones al jugador. Cada opcion puede tener condiciones de visibilidad.',
           nodeCond: 'ConditionNode', subCond: 'Bifurcacion logica', descCond: 'Evalua una condicion y bifurca el flujo. Soporta 10 operadores de comparacion.',
@@ -89,6 +91,8 @@
           nodeStart: 'StartNode', subStart: 'Entry Point', descStart: 'Marks the start of the dialogue graph. Each graph must have exactly one StartNode.',
           nodeEnd: 'EndNode', subEnd: 'Ends Dialogue', descEnd: 'Terminates graph execution. Can indicate a reason for analytics.',
           nodeAI: 'AIResponseNode', subAI: 'AI Generates Response', descAI: 'AI dynamically generates text using LlamaInterface and the NPC CharacterIdentity.',
+          lbAICostTitle: 'Token cost in the editor',
+          lbAICostText: 'The node shows what its prompt costs (CharacterIdentity + WorldContext + template). If the graph has a model assigned, it is tokenized with that model real vocabulary without loading it into memory; otherwise it falls back to the ~4 characters per token estimate and the number is shown with a "~". The usage bar only appears when a model is loaded: without one there is no context window to measure against.',
           nodeStatic: 'StaticResponseNode', subStatic: 'Pre-written Text', descStatic: 'Shows fixed text, no AI generation. Supports variable substitution.',
           nodeChoice: 'PlayerChoiceNode', subChoice: 'Player Options', descChoice: 'Presents options to the player. Each option can have visibility conditions.',
           nodeCond: 'ConditionNode', subCond: 'Logical Branching', descCond: 'Evaluates a condition and branches flow. Supports 10 comparison operators.',
@@ -735,6 +739,16 @@
           </div>
           <div class="p-8 space-y-8">
             <p class="text-gray-400 text-sm leading-relaxed" data-i18n="descAI">La IA genera texto...</p>
+
+            <div class="p-4 rounded-lg border border-ai-green/30 bg-ai-green/5">
+              <p class="text-ai-green font-bold text-sm mb-1" data-i18n="lbAICostTitle">Costo en tokens en el editor</p>
+              <p class="text-gray-300 text-sm" data-i18n="lbAICostText">El nodo muestra lo que cuesta su prompt
+                (CharacterIdentity + WorldContext + plantilla). Si el grafo tiene un modelo asignado, se tokeniza con el
+                vocabulario real de ese modelo sin cargarlo en memoria; si no, se cae a la estimación de ~4 caracteres
+                por token y el número se muestra con "~". La barra de uso sólo aparece cuando hay un modelo cargado:
+                sin él no hay ventana de contexto contra la cual medir.</p>
+            </div>
+
             <div>
               <h4 class="text-ai-cyan font-bold mb-4 flex items-center gap-2 border-b border-border-default pb-2"><span
                   class="w-1 h-4 bg-ai-cyan rounded-full"></span> <span data-i18n="lbParams">Parametros</span></h4>


### PR DESCRIPTION
## Qué pasa

Auditoría de la wiki contra el código real del addon y del GDExtension. La documentación no estaba "un poco vieja": las páginas de API listaban métodos en tablas cuyos enlaces no llevaban a ninguna parte, y familias enteras de la API no figuraban.

## Lo que estaba roto

| Página | Hallazgo |
|---|---|
| `API/llama-interface.html` | **13 anclas rotas**. Sin documentar: sampling (20 métodos), stop sequences (3), timeout (3), las **7 señales** y las **8 propiedades**. Cero menciones a `temperature` en toda la página |
| `API/dialogue-manager.html` | **13 anclas rotas**. `@export ai_preset` sin documentar. `set_ai_preset()` está marcado obsoleto en el código y la wiki no lo decía |
| `API/resources.html` | `DialogueGraph.model_path` y `ai_preset` ausentes; 12 propiedades de `AIPreset`, 16 de `ModelConfig` y todos sus métodos. 21 claves i18n traducidas y nunca cableadas al HTML |

## Lo que se hizo

Todo verificado línea por línea contra `gdextension/src/llama_interface.cpp` y los `.gd`, no contra nombres:

- **LlamaInterface**: las 3 tablas que faltaban, propiedades, señales y las 13 secciones de detalle. Se documentan los comportamientos que sólo se ven leyendo el C++:
  - `generate()` bloquea el hilo que la llama
  - `cancel_generation()` hace `wait_for_task_completion`, o sea que **bloquea hasta que el worker frena de verdad**
  - `get_generation_progress()` es contra `max_tokens`, así que si el modelo corta antes nunca llega a 1.0
  - `frequency_penalty`, `presence_penalty` y `repeat_last_n` tienen setter/getter pero **no** `ADD_PROPERTY`: hay que llamarlos, no asignarlos
  - las 22 claves que devuelve `get_model_info()`
- **DialogueManager**: las 13 secciones faltantes. `end_dialogue()` siempre descarga el modelo; `query_action`/`query_value` devuelven el default si nadie está conectado a la señal, así que el diálogo no se cuelga.
- **Resources**: propiedades y métodos completos. `DialogueGraph.model_path` entra con la explicación de para qué sirve — es lo que `start_dialogue` carga solo y lo que el editor usa para contar tokens.
- **Higiene i18n**: en vez de duplicar, se cablearon las 21 traducciones huérfanas que ya estaban escritas. Balance es/en verificado, cero claves usadas-sin-definir, cero definidas-sin-usar, y el `<script>` de cada página pasa `node --check`.
- **`count_tokens` + `vocab_only`** (commit original de esta rama): la receta para tokenizar sin cargar los pesos, y la tabla de las 8 claves reales de `load_model`.

Aparte, un fix chico: `token_counter.gd.uid` quedó sin commitear en #240. Todos los demás scripts de `core/` tienen el suyo trackeado.

## Lo que NO se tocó, a propósito

- `API/memory-manager.html` y `API/tts-manager.html` son stubs "Coming Soon" honestos: `MemoryManager` y `TTSManager` **no existen** en el código. No son documentación desactualizada, son promesas.
- `Technical/token-report.html` habla del tokenizador de Claude, no del plugin.
- Las claves i18n huérfanas de `Technical/dialogue-nodes.html` son la deuda del sidebar duplicado (#238), no de esta auditoría.

## Sin verificar

Ninguna página se abrió en un navegador. La validación fue estructural: anclas, balance i18n, anidamiento HTML y sintaxis del JS.

Relacionado: #6 tiene "Documentación actualizada" como criterio de aceptación sin tildar. Esto lo cubre para la superficie de API de generación async/streaming, pero el tilde lo pone quien haga el smoke.
