### PR TITLE
chore(release): 0.4.0 y arreglar el trigger del workflow de release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,7 +56,7 @@ body:
       value: |
         - OS: [e.g., Windows 11, Ubuntu 22.04]
         - Godot version: [e.g., 4.5]
-        - OhMyDialogSystem version: [e.g., 0.3.0-dev]
+        - OhMyDialogSystem version: [e.g., 0.4.0]
         - LLM Model: [e.g., Qwen2.5-0.5B-Q4]
     validations:
       required: true

--- a/.github/workflows/release-gdextension.yml
+++ b/.github/workflows/release-gdextension.yml
@@ -1,5 +1,6 @@
 # GitHub Actions workflow for releasing OhMyDialogSystem GDExtension
-# Triggered when a version tag (vX.X.X) is pushed or manually via workflow_dispatch
+# Triggered when a version tag (vX.Y.Z or vX.Y.Z-suffix) is pushed, or manually
+# via workflow_dispatch
 # Builds for Windows, Linux, and macOS with dynamic backend loading
 
 name: Release GDExtension
@@ -8,6 +9,9 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      # Pre-releases (v1.0.0-rc1, v0.4.0-dev). Without this the tag is pushed
+      # and nothing runs: the filter has to match the whole ref name.
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
   # Manual trigger for testing builds without creating a release
   workflow_dispatch:
@@ -334,8 +338,10 @@ jobs:
           ls -la release/*.zip release/*.tar.gz
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
+          # A tag carrying a suffix (-dev, -rc1) is not a stable release
+          prerelease: ${{ contains(env.VERSION, '-') }}
           files: |
             release/*.zip
             release/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Godot 4.5+](https://img.shields.io/badge/Godot-4.5%2B-blue?logo=godot-engine)
 ![License Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue)
-![Version](https://img.shields.io/badge/Version-0.3.0--dev-orange)
+![Version](https://img.shields.io/badge/Version-0.4.0-orange)
 ![Core](https://img.shields.io/badge/Core-88%25-green)
 ![Editor](https://img.shields.io/badge/Editor-35%25-yellow)
 
@@ -78,7 +78,7 @@
 
 ## Installation
 
-> **Note:** The addon is currently in active development (v0.3.0-dev).
+> **Note:** The addon is currently in active development (v0.4.0).
 > Check the [Releases](https://github.com/lobinuxsoft/OhMyDialogSystem/releases) page for the latest version.
 
 1. Download the latest release or clone the repository

--- a/addons/ohmydialog/plugin.cfg
+++ b/addons/ohmydialog/plugin.cfg
@@ -3,5 +3,5 @@
 name="OhMyDialogSystem"
 description="AI-powered dialogue system for Godot with local LLM inference, persistent memories, and text-to-speech."
 author="lobinuxsoft"
-version="0.3.0-dev"
+version="0.4.0"
 script="plugin.gd"


### PR DESCRIPTION
## Por qué

Auditando el estado de los PRs salió que este repo **nunca publicó un release**. No es que falte automatización: el pipeline que ya existe nunca corrió.

## Lo que estaba roto

- El filtro de tags era `v[0-9]+.[0-9]+.[0-9]+`. Los patrones de GitHub Actions matchean el **ref completo**, así que `v0.3.0-dev` quedaba afuera. El tag se creó, no despertó a nadie, y `gh run list` sobre este workflow devuelve **cero corridas**.
- `plugin.cfg` llevaba **86 commits** clavado en `0.3.0-dev` — con 17 `feat:` y 15 `fix:` adentro.

## Lo que hace este PR

- Agrega el patrón `v[0-9]+.[0-9]+.[0-9]+-*` para que los tags con sufijo disparen, y los marca como `prerelease` en el Release.
- Sube `softprops/action-gh-release` de v1 a v2.
- Bump a `0.4.0` en los cuatro lugares donde vivía el número: `plugin.cfg`, el badge del README, la nota de estado y la plantilla de bug report.

## Sin verificar

El workflow no se ejecutó: sólo se validó que el YAML parsea y que los dos patrones quedan bien formados. La prueba real es el tag, y ese paso va después del merge a `main`.

## Ojo con el número

`0.3.0-dev` se puso el 2026-01-11 y los 86 commits arrancaron **ese mismo día**: leído literal, este trabajo *es* el contenido de 0.3.0 y correspondería soltar el sufijo. Va `0.4.0` porque es lo acordado; si preferís `0.3.0`, se cambia antes del tag.